### PR TITLE
Fix login overlay flow without reloads

### DIFF
--- a/index.html
+++ b/index.html
@@ -56,7 +56,7 @@
         <button class="pill" onclick="window.location.href='teoriacatala.html'">à</button>
         <button class="pill" onclick="window.location.href='https://focuscat.onrender.com/'">FE</button>
         <span id="activeUser" class="chip"></span>
-<button class="pill" onclick="localStorage.removeItem('lastStudent'); location.reload();">Canvia d'usuari</button>
+        <button id="switchUserBtn" class="pill">Canvia d'usuari</button>
         <button id="logoutBtn" class="pill">Tanca sessió</button>
 
       </nav>
@@ -262,11 +262,7 @@ Llengua catalana i castellana (ortografia, categories gramaticals, sintaxi), i Q
 
     // 🔹 Mostra overlay si no hi ha usuari actiu
     const current = localStorage.getItem('lastStudent');
-    if(!current){
-      overlay.style.display = 'flex';
-    } else {
-      overlay.style.display = 'none';
-    }
+    overlay.style.display = current ? 'none' : 'flex';
 
     // 🔹 Entrar amb usuari existent
     btnSelect.addEventListener('click', ()=>{
@@ -274,7 +270,7 @@ Llengua catalana i castellana (ortografia, categories gramaticals, sintaxi), i Q
       if(!name) return alert('Selecciona un usuari.');
       localStorage.setItem('lastStudent', name);
       overlay.style.display = 'none';
-      location.reload(); // 🔸 ara el main.js ja es carregarà amb usuari actiu
+      document.dispatchEvent(new CustomEvent('focusquiz:user-login'));
     });
 
     // 🔹 Crear nou usuari
@@ -285,8 +281,10 @@ Llengua catalana i castellana (ortografia, categories gramaticals, sintaxi), i Q
       if(!users.includes(name)) users.push(name);
       localStorage.setItem('students', JSON.stringify(users));
       localStorage.setItem('lastStudent', name);
+      refreshUsers();
+      inputNew.value = '';
       overlay.style.display = 'none';
-      location.reload();
+      document.dispatchEvent(new CustomEvent('focusquiz:user-login'));
     });
 
     // 🔹 Esborrar usuari
@@ -297,6 +295,10 @@ Llengua catalana i castellana (ortografia, categories gramaticals, sintaxi), i Q
       localStorage.setItem('students', JSON.stringify(users));
       if(localStorage.getItem('lastStudent') === name) localStorage.removeItem('lastStudent');
       refreshUsers();
+      if(!localStorage.getItem('lastStudent')){
+        overlay.style.display = 'flex';
+        document.dispatchEvent(new CustomEvent('focusquiz:user-logout'));
+      }
     });
 
     refreshUsers();

--- a/main.js
+++ b/main.js
@@ -2221,31 +2221,25 @@ $('#btnSkip').onclick = skip;
 
 /* ===================== INIT ===================== */
 
-function ensureUser(){
-  const user = localStorage.getItem('lastStudent');
-  if(!user){
-    // Si no hi ha usuari loguejat, redirigeix o mostra un avís
-    alert('Cal iniciar sessió abans de continuar.');
-    location.href = 'index.html'; // o la pàgina de login
-    return false;
-  }
-  console.log('Sessió activa com:', user);
-  return true;
-}
+let initializedUser = null;
 
 function ensureUser(){
   const user = localStorage.getItem('lastStudent');
+  const overlay = document.getElementById('loginOverlay');
   if(!user){
-    alert('Cal iniciar sessió abans de continuar.');
-    location.href = 'index.html'; // torna al login si no hi ha sessió
+    if(overlay) overlay.style.display = 'flex';
     return false;
   }
-  console.log('Sessió activa com:', user);
+  if(overlay) overlay.style.display = 'none';
   return true;
 }
 
 function init(){
   if(!ensureUser()) return; // ✅ comprova sessió abans d’inicialitzar
+
+  const current = localStorage.getItem('lastStudent');
+  if(initializedUser === current) return;
+  initializedUser = current;
 
   buildHome();
   showView('home');
@@ -2257,7 +2251,6 @@ function init(){
   if(fs) fs.addEventListener('input', renderResults);
 
   // 🔹 Mostra el nom de l’usuari actiu
-  const current = localStorage.getItem('lastStudent');
   const chip = document.querySelector('#activeUser');
   if(current && chip) chip.textContent = `👤 ${current}`;
 
@@ -2265,14 +2258,37 @@ function init(){
   const logoutBtn = document.getElementById('logoutBtn');
   if (logoutBtn) {
     logoutBtn.addEventListener('click', () => {
-      if (confirm(`Vols tancar la sessió de ${current}?`)) {
-        localStorage.removeItem('lastStudent');
-        alert('Sessió tancada correctament.');
-        location.href = 'index.html';
-      }
+      localStorage.removeItem('lastStudent');
+      initializedUser = null;
+      if (chip) chip.textContent = '';
+      const overlay = document.getElementById('loginOverlay');
+      if (overlay) overlay.style.display = 'flex';
+      showView('home');
+      document.dispatchEvent(new CustomEvent('focusquiz:user-logout'));
+    });
+  }
+
+  const switchUserBtn = document.getElementById('switchUserBtn');
+  if (switchUserBtn) {
+    switchUserBtn.addEventListener('click', () => {
+      localStorage.removeItem('lastStudent');
+      initializedUser = null;
+      if (chip) chip.textContent = '';
+      const overlay = document.getElementById('loginOverlay');
+      if (overlay) overlay.style.display = 'flex';
+      showView('home');
+      document.dispatchEvent(new CustomEvent('focusquiz:user-logout'));
     });
   }
 }
 
 document.addEventListener('DOMContentLoaded', init);
+
+document.addEventListener('focusquiz:user-login', init);
+document.addEventListener('focusquiz:user-logout', () => {
+  initializedUser = null;
+  const chip = document.querySelector('#activeUser');
+  if (chip) chip.textContent = '';
+  ensureUser();
+});
 


### PR DESCRIPTION
## Summary
- show and hide the login overlay without forcing alerts or redirects by updating `ensureUser`
- dispatch custom login/logout events so the app can initialize after credentials are provided
- replace page reloads on login switching with overlay toggles for a smoother session change

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68e585cfa9f4832d8eb326712cf2c405