### PR TITLE
Limit results and tutor recommendations to active user

### DIFF
--- a/index.html
+++ b/index.html
@@ -42,24 +42,34 @@
 </div>
 
 <body>
-  <header>
-    <div class="wrap row">
-      <div class="brand">
-        <div class="logo" aria-hidden="true">FQ</div>
-        <h1>Focus Academy · Espai de repàs</h1>
-      </div>
-      <nav class="right">
-        <button class="pill" onclick="showView('home')">Inici</button>
-        <button class="pill" onclick="showView('results')">Resultats</button>
-        <button class="pill" onclick="showView('about')">Sobre</button>
-        <button class="pill" onclick="window.location.href='teoria.html'">π</button>
-        <button class="pill" onclick="window.location.href='teoriacatala.html'">à</button>
-        <button class="pill" onclick="window.location.href='https://focuscat.onrender.com/'">FE</button>
-        <span id="activeUser" class="chip"></span>
-<button class="pill" onclick="localStorage.removeItem('lastStudent'); location.reload();">Canvia d'usuari</button>
-        <button id="logoutBtn" class="pill">Tanca sessió</button>
+  <header class="topbar">
+    <div class="wrap row header-bar">
 
+      <!-- 🔹 Marca -->
+      <div class="brand">
+        <div class="logo">FQ</div>
+        <h1>Focus Academy</h1>
+      </div>
+
+      <!-- 🔹 Navegació principal -->
+      <nav class="main-nav" aria-label="Navegació principal">
+        <button class="pill nav-btn" data-view="home" type="button" onclick="showView('home')">🏠 Inici</button>
+        <button class="pill nav-btn" data-view="results" type="button" onclick="showView('results')">📊 Resultats</button>
+        <button class="pill nav-btn" data-view="about" type="button" onclick="showView('about')">ℹ️ Sobre</button>
+        <a class="pill" href="teoria.html" title="Teoria matemàtica">π</a>
+        <a class="pill" href="teoriacatala.html" title="Teoria catalana">à</a>
+        <a class="pill" href="https://focuscat.onrender.com/" target="_blank" rel="noopener" title="Focus Exams">FE</a>
       </nav>
+
+      <!-- 🔹 Usuari actiu -->
+      <div class="user-controls">
+        <span id="activeUser" class="chip user-chip" aria-live="polite">
+          👤 <span class="label">Sessió no iniciada</span>
+        </span>
+        <button id="switchUserBtn" class="pill small" type="button">Canvia</button>
+        <button id="logoutBtn" class="pill small" type="button">Surt</button>
+      </div>
+
     </div>
   </header>
 
@@ -86,7 +96,11 @@ document.addEventListener('DOMContentLoaded', ()=>{
   // 🔹 Mostra l'usuari actiu (si n'hi ha)
   const current = localStorage.getItem('lastStudent');
   const badge = document.getElementById('activeUser');
-  if (current && badge) badge.textContent = `👤 ${current}`;
+  if (badge) {
+    const label = badge.querySelector('.label');
+    if (label) label.textContent = current || 'Sessió no iniciada';
+    badge.classList.toggle('is-empty', !current);
+  }
 });
 </script>
   </div>
@@ -262,11 +276,7 @@ Llengua catalana i castellana (ortografia, categories gramaticals, sintaxi), i Q
 
     // 🔹 Mostra overlay si no hi ha usuari actiu
     const current = localStorage.getItem('lastStudent');
-    if(!current){
-      overlay.style.display = 'flex';
-    } else {
-      overlay.style.display = 'none';
-    }
+    overlay.style.display = current ? 'none' : 'flex';
 
     // 🔹 Entrar amb usuari existent
     btnSelect.addEventListener('click', ()=>{
@@ -274,7 +284,7 @@ Llengua catalana i castellana (ortografia, categories gramaticals, sintaxi), i Q
       if(!name) return alert('Selecciona un usuari.');
       localStorage.setItem('lastStudent', name);
       overlay.style.display = 'none';
-      location.reload(); // 🔸 ara el main.js ja es carregarà amb usuari actiu
+      document.dispatchEvent(new CustomEvent('focusquiz:user-login'));
     });
 
     // 🔹 Crear nou usuari
@@ -285,8 +295,10 @@ Llengua catalana i castellana (ortografia, categories gramaticals, sintaxi), i Q
       if(!users.includes(name)) users.push(name);
       localStorage.setItem('students', JSON.stringify(users));
       localStorage.setItem('lastStudent', name);
+      refreshUsers();
+      inputNew.value = '';
       overlay.style.display = 'none';
-      location.reload();
+      document.dispatchEvent(new CustomEvent('focusquiz:user-login'));
     });
 
     // 🔹 Esborrar usuari
@@ -297,7 +309,35 @@ Llengua catalana i castellana (ortografia, categories gramaticals, sintaxi), i Q
       localStorage.setItem('students', JSON.stringify(users));
       if(localStorage.getItem('lastStudent') === name) localStorage.removeItem('lastStudent');
       refreshUsers();
+      if(!localStorage.getItem('lastStudent')){
+        overlay.style.display = 'flex';
+        document.dispatchEvent(new CustomEvent('focusquiz:user-logout'));
+      }
     });
+
+    // 🔹 Botó "Canvia d'usuari"
+    const switchBtn = document.getElementById('switchUserBtn');
+    if (switchBtn) {
+      switchBtn.addEventListener('click', () => {
+        localStorage.removeItem('lastStudent');
+        overlay.style.display = 'flex';
+        document.dispatchEvent(new CustomEvent('focusquiz:user-logout'));
+      });
+    }
+
+    // 🔹 Botó "Tanca sessió"
+    const logoutBtn = document.getElementById('logoutBtn');
+    if (logoutBtn) {
+      logoutBtn.addEventListener('click', () => {
+        const currentName = localStorage.getItem('lastStudent');
+        if (!currentName || confirm(`Vols tancar la sessió de ${currentName}?`)) {
+          localStorage.removeItem('lastStudent');
+          overlay.style.display = 'flex';
+          if (currentName) alert('Sessió tancada.');
+          document.dispatchEvent(new CustomEvent('focusquiz:user-logout'));
+        }
+      });
+    }
 
     refreshUsers();
   });

--- a/main.js
+++ b/main.js
@@ -22,29 +22,68 @@ const simplifyFrac = (n,d)=>{ const g=gcd(n,d); return [n/g, d/g] };
 const store = {
   get k() { return 'focus-math-results-v1'; },
 
-  all() {
-    const user = localStorage.getItem('lastStudent') || 'Anònim';
+  currentUser() {
+    return localStorage.getItem('lastStudent') || null;
+  },
+
+  defaultUser() {
+    return this.currentUser() || 'Anònim';
+  },
+
+  load() {
     try {
-      const data = JSON.parse(localStorage.getItem(this.k) || '{}');
-      return data[user] || [];
+      const raw = JSON.parse(localStorage.getItem(this.k) || '{}');
+      if (Array.isArray(raw)) {
+        const user = this.defaultUser();
+        const migrated = { [user]: raw };
+        localStorage.setItem(this.k, JSON.stringify(migrated));
+        return migrated;
+      }
+      if (!raw || typeof raw !== 'object') return {};
+      return raw;
     } catch {
-      return [];
+      return {};
     }
   },
 
+  all(options = {}) {
+    const data = this.load();
+    const scope = options.scope || 'current';
+
+    const sortDesc = (entries) => entries.slice().sort((a, b) => {
+      const timeB = new Date(b.at).getTime() || 0;
+      const timeA = new Date(a.at).getTime() || 0;
+      return timeB - timeA;
+    });
+
+    if (scope === 'all') {
+      const merged = Object.values(data)
+        .reduce((acc, entries) => acc.concat(entries || []), []);
+      return sortDesc(merged);
+    }
+
+    const targetUser = options.user !== undefined ? options.user : this.currentUser();
+    if (!targetUser) return [];
+
+    const entries = Array.isArray(data[targetUser]) ? data[targetUser] : [];
+    return sortDesc(entries);
+  },
+
   save(entry) {
-    const user = localStorage.getItem('lastStudent') || 'Anònim';
-    const data = JSON.parse(localStorage.getItem(this.k) || '{}');
-    if (!data[user]) data[user] = [];
+    const user = this.defaultUser();
+    const data = this.load();
+    if (!Array.isArray(data[user])) data[user] = [];
     data[user].push(entry);
     localStorage.setItem(this.k, JSON.stringify(data));
   },
 
   clear() {
-    const user = localStorage.getItem('lastStudent') || 'Anònim';
-    const data = JSON.parse(localStorage.getItem(this.k) || '{}');
-    delete data[user];
-    localStorage.setItem(this.k, JSON.stringify(data));
+    const user = this.defaultUser();
+    const data = this.load();
+    if (user in data) delete data[user];
+    const remaining = Object.keys(data).length;
+    if (!remaining) localStorage.removeItem(this.k);
+    else localStorage.setItem(this.k, JSON.stringify(data));
   }
 };
 
@@ -88,6 +127,9 @@ let timerHandle = null;
 
 function showView(name){
   ['home','config','quiz','results','about'].forEach(v=> $('#view-'+v).classList.toggle('hidden', v!==name));
+  $$('.nav-btn[data-view]').forEach(btn=>{
+    btn.classList.toggle('active', btn.dataset.view === name);
+  });
   if(name==='results') renderResults();
 }
 
@@ -886,6 +928,11 @@ function finishQuiz(timeUp){
     score,
     wrongs: session.wrongs
   });
+
+  renderResults();
+  if (typeof showRecommendation === 'function') {
+    showRecommendation('#recommendationText');
+  }
 
   session.done = true;
   const wrongsBtn = session.wrongs.length ? `<button onclick="redoWrongs()">Refés només els errors</button>` : '';
@@ -2075,8 +2122,12 @@ function scatterSVG(points){
 // ==== RENDER PRINCIPAL DE RESULTATS + PERFIL ====
 function renderResults(){
   const data = store.all();
-  const modFilter = $('#filter-module').value || '';
-  const nameFilter = ($('#filter-student').value||'').toLowerCase();
+  const modSelect = $('#filter-module');
+  const nameInput = $('#filter-student');
+  const modFilter = modSelect ? modSelect.value : '';
+  const nameFilter = (nameInput && nameInput.value ? nameInput.value : '').toLowerCase();
+  const tableWrap = $('#resultsTable');
+  if(!tableWrap) return;
 
   const filtered = data.filter(r =>
     (!modFilter || r.module===modFilter) &&
@@ -2085,7 +2136,7 @@ function renderResults(){
 
   // Taula
   if(!filtered.length){
-    $('#resultsTable').innerHTML = '<div class="chip">No hi ha dades.</div>';
+    tableWrap.innerHTML = '<div class="chip">No hi ha dades per a aquesta sessió.</div>';
     renderAnalytics([], nameFilter); // neteja i mostra hint si cal
     return;
   }
@@ -2103,7 +2154,7 @@ function renderResults(){
       <td>${fmtTime(r.time_spent)}</td>
     </tr>`;
   }).join('');
-  $('#resultsTable').innerHTML = `
+  tableWrap.innerHTML = `
 <table>
   <thead>
     <tr><th>#</th><th>Data</th><th>Alumne/a</th><th>Mòdul</th><th>Nivell</th><th>Encerts</th><th>Puntuació</th><th>Temps</th></tr>
@@ -2180,7 +2231,7 @@ function renderAnalytics(filtered, nameFilter){
 
 
 function exportCSV(){
-  const data = store.all();
+  const data = store.all({ scope: 'all' });
   if(!data.length){ alert('No hi ha dades per exportar.'); return }
   const header = ['data','alumne','modul','nivell','preguntes','correctes','puntuacio','temps_limit','temps_consumit'];
   const lines = [header.join(',')];
@@ -2221,31 +2272,25 @@ $('#btnSkip').onclick = skip;
 
 /* ===================== INIT ===================== */
 
-function ensureUser(){
-  const user = localStorage.getItem('lastStudent');
-  if(!user){
-    // Si no hi ha usuari loguejat, redirigeix o mostra un avís
-    alert('Cal iniciar sessió abans de continuar.');
-    location.href = 'index.html'; // o la pàgina de login
-    return false;
-  }
-  console.log('Sessió activa com:', user);
-  return true;
-}
+let initializedUser = null;
 
 function ensureUser(){
   const user = localStorage.getItem('lastStudent');
+  const overlay = document.getElementById('loginOverlay');
   if(!user){
-    alert('Cal iniciar sessió abans de continuar.');
-    location.href = 'index.html'; // torna al login si no hi ha sessió
+    if(overlay) overlay.style.display = 'flex';
     return false;
   }
-  console.log('Sessió activa com:', user);
+  if(overlay) overlay.style.display = 'none';
   return true;
 }
 
 function init(){
   if(!ensureUser()) return; // ✅ comprova sessió abans d’inicialitzar
+
+  const current = localStorage.getItem('lastStudent');
+  if(initializedUser === current) return;
+  initializedUser = current;
 
   buildHome();
   showView('home');
@@ -2257,22 +2302,41 @@ function init(){
   if(fs) fs.addEventListener('input', renderResults);
 
   // 🔹 Mostra el nom de l’usuari actiu
-  const current = localStorage.getItem('lastStudent');
   const chip = document.querySelector('#activeUser');
-  if(current && chip) chip.textContent = `👤 ${current}`;
-
-  // 🔹 Configura el botó de tancar sessió
-  const logoutBtn = document.getElementById('logoutBtn');
-  if (logoutBtn) {
-    logoutBtn.addEventListener('click', () => {
-      if (confirm(`Vols tancar la sessió de ${current}?`)) {
-        localStorage.removeItem('lastStudent');
-        alert('Sessió tancada correctament.');
-        location.href = 'index.html';
-      }
-    });
+  if (chip) {
+    const label = chip.querySelector('.label');
+    if (label) label.textContent = current || 'Sessió no iniciada';
+    chip.classList.toggle('is-empty', !current);
   }
+
+  if (typeof showRecommendation === 'function') {
+    showRecommendation('#recommendationText');
+  }
+
+  if (typeof renderResults === 'function') {
+    renderResults();
+  }
+
 }
 
 document.addEventListener('DOMContentLoaded', init);
+
+document.addEventListener('focusquiz:user-login', init);
+document.addEventListener('focusquiz:user-logout', () => {
+  initializedUser = null;
+  const chip = document.querySelector('#activeUser');
+  if (chip) {
+    const label = chip.querySelector('.label');
+    if (label) label.textContent = 'Sessió no iniciada';
+    chip.classList.add('is-empty');
+  }
+  if (typeof showRecommendation === 'function') {
+    showRecommendation('#recommendationText');
+  }
+  if (typeof renderResults === 'function') {
+    renderResults();
+  }
+  showView('home');
+  ensureUser();
+});
 

--- a/style.css
+++ b/style.css
@@ -44,35 +44,136 @@ body{
     linear-gradient(180deg, var(--bg), #eef2ff 220px);
 }
 
-/* ===== Header ===== */
-header{
-  position:sticky; top:0; z-index:5;
-  backdrop-filter:saturate(1.1) blur(8px);
-  background:rgba(255,255,255,.7);
-  border-bottom:1px solid var(--hair);
+/* ========== TOPBAR CLEAN ========== */
+.topbar {
+  background: #fff;
+  border-bottom: 1px solid #e5e7eb;
+  position: sticky;
+  top: 0;
+  z-index: 100;
 }
-.wrap{max-width:1100px; margin:0 auto; padding: clamp(14px, 2vw, 24px);}
-.brand{display:flex; align-items:center; gap:12px;}
-.logo {
-  width: 38px;
-  height: 38px;
-  display: grid;
-  place-items: center;
-  border-radius: 12px;
-  background: conic-gradient(from 180deg, var(--p-blue), var(--p-lilac), var(--p-rose), var(--p-blue));
-  box-shadow: var(--shadow);
-  color: #0f172a;
-  font-weight: 900;
+
+.wrap { max-width: 1100px; margin: 0 auto; padding: clamp(14px, 2vw, 24px); }
+.row { display: flex; justify-content: space-between; align-items: center; gap: 0.5rem; }
+
+.header-bar {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  padding: 0.6rem 1rem;
 }
-.brand h1{font-size:1.1rem; margin:0; letter-spacing:.2px}
-nav{display:flex; gap:8px; flex-wrap:wrap}
-.row{display:flex; justify-content:space-between; align-items:center; gap:12px}
-.pill{
-  border:1px solid var(--hair); color:var(--ink); background:#ffffffcc;
-  padding:10px 14px; border-radius:999px; cursor:pointer; transition:.2s ease; font-weight:700; font-size:.92rem
+
+/* Marca */
+.brand {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
 }
-.pill:hover{transform:translateY(-1px); background:#fff}
-.right{display:flex; align-items:center; gap:10px}
+.brand .logo {
+  background: var(--primary, #7aa2ff);
+  color: white;
+  font-weight: 700;
+  padding: 0.35rem 0.55rem;
+  border-radius: 0.5rem;
+}
+.brand h1 {
+  font-size: 1rem;
+  margin: 0;
+}
+
+/* Navegació */
+.main-nav {
+  display: flex;
+  gap: 0.4rem;
+  flex-wrap: wrap;
+  justify-content: center;
+}
+
+.main-nav .pill {
+  background: #f9fafb;
+  border: 1px solid #e5e7eb;
+  border-radius: 0.5rem;
+  padding: 0.4rem 0.7rem;
+  font-size: 0.9rem;
+  cursor: pointer;
+  transition: background 0.2s;
+  font-weight: 600;
+  color: inherit;
+  text-decoration: none;
+  box-shadow: none;
+}
+.main-nav .pill:hover {
+  background: #e8eefc;
+}
+
+.nav-btn.active {
+  background: #e0e7ff;
+  border-color: #c7d2fe;
+  color: #1e3a8a;
+}
+
+/* Usuari */
+.user-controls {
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+}
+.user-controls .pill.small {
+  padding: 0.35rem 0.6rem;
+  font-size: 0.85rem;
+  font-weight: 600;
+  background: #f9fafb;
+  border: 1px solid #e5e7eb;
+  border-radius: 0.5rem;
+  color: inherit;
+  box-shadow: none;
+  transition: background 0.2s;
+}
+.user-controls .pill.small:hover {
+  background: #e8eefc;
+}
+.user-chip {
+  background: #f1f5f9;
+  border-radius: 999px;
+  padding: 0.3rem 0.8rem;
+  font-size: 0.85rem;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  border: 1px solid #e2e8f0;
+}
+.user-chip.is-empty {
+  color: #64748b;
+  border-style: dashed;
+}
+
+@media (max-width: 900px) {
+  .header-bar {
+    flex-direction: column;
+    align-items: stretch;
+  }
+  .brand,
+  .user-controls {
+    width: 100%;
+    justify-content: space-between;
+  }
+  .main-nav {
+    width: 100%;
+    justify-content: center;
+  }
+}
+
+@media (max-width: 560px) {
+  .user-controls {
+    flex-wrap: wrap;
+    justify-content: center;
+  }
+  .user-controls .pill.small {
+    flex: 1 1 45%;
+  }
+}
 .input, select{
   background:#f3f4f6; border:1px solid var(--hair); color:var(--ink);
   border-radius:12px; padding:10px 12px; outline:none; font-size:.95rem

--- a/tutor.js
+++ b/tutor.js
@@ -7,26 +7,82 @@
 
   /* ======== UTILITATS ======== */
   const $ = (q) => document.querySelector(q);
+  const STORAGE_KEY = 'progress';
+
+  const escapeHTML = (value) => String(value ?? '')
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+
+  const activeUser = () => {
+    const name = localStorage.getItem('lastStudent');
+    return name ? name : null;
+  };
+
+  const fallbackUser = () => activeUser() || 'Anònim';
+
+  const loadProgress = () => {
+    try {
+      const raw = JSON.parse(localStorage.getItem(STORAGE_KEY) || '{}');
+      if (!raw || typeof raw !== 'object' || Array.isArray(raw)) return {};
+      const values = Object.values(raw);
+      if (values.length && Array.isArray(values[0])) {
+        const migrated = { [fallbackUser()]: raw };
+        localStorage.setItem(STORAGE_KEY, JSON.stringify(migrated));
+        return migrated;
+      }
+      return raw;
+    } catch {
+      return {};
+    }
+  };
+
+  const saveProgress = (data) => {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(data));
+  };
+
+  const ensureUserBucket = (data, user) => {
+    if (!user) return null;
+    if (!data[user] || typeof data[user] !== 'object') data[user] = {};
+    return data[user];
+  };
+
+  const moduleLabel = (id) => {
+    if (typeof MODULES !== 'undefined' && Array.isArray(MODULES)) {
+      const found = MODULES.find(m => m.id === id);
+      if (found) return found.name;
+    }
+    return id;
+  };
 
   // Guarda resultat de cada pregunta
   window.saveResult = function(moduleName, questionText, correct){
-    const data = JSON.parse(localStorage.getItem('progress') || '{}');
-    if(!data[moduleName]) data[moduleName] = [];
-    data[moduleName].push({
+    const data = loadProgress();
+    const user = fallbackUser();
+    const bucket = ensureUserBucket(data, user);
+    if (!bucket) return;
+    if (!Array.isArray(bucket[moduleName])) bucket[moduleName] = [];
+    bucket[moduleName].push({
       question: questionText,
       correct: !!correct,
       time: Date.now()
     });
-    localStorage.setItem('progress', JSON.stringify(data));
+    saveProgress(data);
   };
 
   // Obté el rendiment mitjà per mòdul
-  window.getPerformance = function(){
-    const data = JSON.parse(localStorage.getItem('progress') || '{}');
+  window.getPerformance = function(targetUser){
+    const data = loadProgress();
+    const user = targetUser || activeUser();
+    if (!user) return {};
+    const bucket = data[user];
+    if (!bucket || typeof bucket !== 'object') return {};
     const summary = {};
-    for(const mod in data){
-      const items = data[mod];
-      if(items.length === 0) continue;
+    for(const mod in bucket){
+      const items = bucket[mod];
+      if(!Array.isArray(items) || items.length === 0) continue;
       const correct = items.filter(x => x.correct).length;
       summary[mod] = Math.round((correct / items.length) * 100);
     }
@@ -34,24 +90,37 @@
   };
 
   // Recomana el mòdul més fluix
-  window.recommendNextModule = function(){
-    const perf = getPerformance();
+  window.recommendNextModule = function(targetUser){
+    const user = targetUser || activeUser();
+    if (!user) return 'Inicia sessió per rebre recomanacions personalitzades.';
+    const safeUser = escapeHTML(user);
+    const perf = getPerformance(user);
     const entries = Object.entries(perf);
-    if(entries.length === 0) return "Encara no hi ha dades per fer recomanacions.";
-    const worst = entries.sort((a,b)=>a[1]-b[1])[0];
-    return `Et recomano practicar més **${worst[0]}**, ja que tens un ${worst[1]}% d'encerts. 💪`;
+    if(entries.length === 0) return `${safeUser} encara no té dades suficients. Completa un examen per generar recomanacions.`;
+    const [modId, pct] = entries.sort((a,b)=>a[1]-b[1])[0];
+    const readable = moduleLabel(modId);
+    const safeModule = escapeHTML(readable);
+    return `${safeUser}, et recomano practicar més <strong>${safeModule}</strong> perquè tens un ${pct}% d'encerts. 💪`;
   };
 
   // Mostra recomanació (pots cridar-la des de la Home)
-  window.showRecommendation = function(selector){
-    const msg = recommendNextModule();
+  window.showRecommendation = function(selector, targetUser){
     const el = $(selector);
-    if(el) el.innerHTML = msg;
+    if(!el) return;
+    el.innerHTML = recommendNextModule(targetUser);
   };
 
-  // (Opcional) Neteja tot el progrés
+  // (Opcional) Neteja el progrés de l'usuari actiu
   window.resetProgress = function(){
-    localStorage.removeItem('progress');
+    const data = loadProgress();
+    const user = activeUser();
+    if (user && data[user]) {
+      delete data[user];
+      if (Object.keys(data).length) saveProgress(data);
+      else localStorage.removeItem(STORAGE_KEY);
+    } else {
+      localStorage.removeItem(STORAGE_KEY);
+    }
     alert('Progrés esborrat.');
   };
 


### PR DESCRIPTION
## Summary
- scope stored results and analytics to the signed-in student while keeping CSV export over the whole dataset
- refresh the tutor advice whenever sessions start, end, or finish an exam so the overlay reflects the active student
- rewrite the tutor progress tracker to store per-user history, migrate legacy data, and sanitize personalized recommendation text

## Testing
- not run (static site)

------
https://chatgpt.com/codex/tasks/task_e_68e585cfa9f4832d8eb326712cf2c405