### PR TITLE
Remove classroom management tools and refactor portal assignment options

### DIFF
--- a/app.html
+++ b/app.html
@@ -271,11 +271,10 @@
         <section class="fq-home-landing" aria-labelledby="focusQuizHomeTitle">
           <div class="fq-home-landing__content">
             <p class="portal-section-title">FocusQuiz · Plataforma educativa</p>
-            <h2 id="focusQuizHomeTitle" class="title">Aprenentatge, reptes i entrenament cognitiu en un sol espai</h2>
-            <p class="subtitle">Crea proves, practica continguts, entra a l'aula amb codi, juga reptes d'aprenentatge i accedeix a FocusMind des del menú superior quan vulguis entrenar atenció, memòria i flexibilitat mental.</p>
+            <h2 id="focusQuizHomeTitle" class="title">Aprenentatge i entrenament cognitiu en un sol espai</h2>
+            <p class="subtitle">Crea proves, practica continguts, entra a l'aula amb codi i accedeix a FocusMind des del menú superior quan vulguis entrenar atenció, memòria i flexibilitat mental.</p>
             <div class="fq-home-landing__chips" aria-label="Àrees disponibles">
               <span>📚 Mòduls d'estudi</span>
-              <span>🎯 Reptes</span>
               <span>🧠 FocusMind</span>
               <span>👥 Aula</span>
               <span>🤖 Tutor virtual</span>
@@ -297,18 +296,6 @@
           <div class="tutor-actions">
           </div>
         </div>
-
-
-        <section id="challengesEntrySection" class="panel card challenge-entry" aria-labelledby="challengesEntryTitle">
-          <div>
-            <p class="portal-section-title">Reptes</p>
-            <h2 id="challengesEntryTitle">Vols jugar als reptes Focus?</h2>
-            <p class="subtitle">Entra a la zona de jocs i tria el repte disponible. Ara mateix: <strong>Joc de la corda</strong>.</p>
-          </div>
-          <div class="challenge-entry__actions">
-            <a class="pill" href="reptes.html">Entrar a Reptes →</a>
-          </div>
-        </section>
 
 
         <section id="classSection" class="panel card home-live-cta home-class-cta" aria-labelledby="homeClassTitle">

--- a/portal/portal.css
+++ b/portal/portal.css
@@ -2609,91 +2609,56 @@
   grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
 }
 
-.classroom-random-grid {
-  display: grid;
-  gap: 1rem;
-  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
-  align-items: end;
-}
-
-.classroom-random-actions {
-  display: grid;
-  gap: 0.5rem;
-  align-content: center;
-}
-
-.classroom-pick-result {
-  margin: 0;
-  font-size: 1rem;
-  color: #0f172a;
-  min-height: 1.5em;
-}
-
-.classroom-history {
+.portal-quiz-options {
   display: flex;
   flex-wrap: wrap;
-  gap: 0.5rem;
-  margin-top: 0.75rem;
-}
-
-.classroom-history .portal-chip,
-.classroom-history .portal-chip--muted {
-  cursor: default;
-}
-
-.classroom-timer-grid {
-  display: grid;
-  gap: 1rem;
-  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
   align-items: center;
+  gap: 0.7rem;
 }
 
-.classroom-timer-controls {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 1rem;
+.portal-quiz-chip {
+  display: inline-flex;
   align-items: center;
-  justify-content: space-between;
-}
-
-.classroom-timer-display {
-  min-width: 160px;
-}
-
-.classroom-timer-time {
-  font-size: 2.4rem;
-  font-weight: 700;
-  color: #0f172a;
-  margin: 0;
-}
-
-.classroom-timer-buttons {
-  display: flex;
-  gap: 0.5rem;
-}
-
-.classroom-timer-bar {
-  position: relative;
-  width: 100%;
-  height: 12px;
+  gap: 0.55rem;
+  width: fit-content;
+  padding: 0.38rem 0.45rem 0.38rem 0.8rem;
+  border: 1px solid rgba(148, 163, 184, 0.36);
   border-radius: 999px;
-  background: rgba(148, 163, 184, 0.25);
-  overflow: hidden;
-  margin-top: 0.5rem;
+  background: #ffffff;
+  color: #334155;
+  font-weight: 500;
+  box-shadow: 0 8px 24px -18px rgba(15, 23, 42, 0.35);
 }
 
-.classroom-timer-bar span {
-  position: absolute;
-  inset: 0 auto 0 0;
-  width: 100%;
-  background: #f6f8ff;
-  transform-origin: left center;
-  transform: scaleX(0);
-  transition: transform 0.2s ease;
+.portal-quiz-chip span {
+  white-space: nowrap;
 }
 
-.classroom-notes {
-  margin-top: 0.5rem;
+.portal-quiz-chip select.input {
+  min-width: 4rem;
+  width: auto;
+  margin: 0;
+  padding: 0.52rem 2rem 0.52rem 0.9rem;
+  border-radius: 12px;
+  border-color: rgba(148, 163, 184, 0.32);
+  background-color: #f8fafc;
+  color: #0f172a;
+  font-weight: 600;
+}
+
+.portal-quiz-chip select[name="time"] {
+  min-width: 7.7rem;
+}
+
+@media (max-width: 560px) {
+  .portal-quiz-options {
+    align-items: stretch;
+  }
+
+  .portal-quiz-chip {
+    width: 100%;
+    justify-content: space-between;
+  }
 }
 
 .portal-actions {

--- a/portal/supabase-portal.html
+++ b/portal/supabase-portal.html
@@ -105,91 +105,8 @@
     <div id="portalTabs" class="portal-tabs hidden" data-portal-tablist role="tablist" aria-label="Eines del professorat">
       <button id="tab-classes" class="portal-tab" type="button" data-tab="classes" role="tab" aria-controls="classesPanel" aria-selected="false">Classes</button>
       <button id="tab-assignments" class="portal-tab" type="button" data-tab="assignments" role="tab" aria-controls="assignmentsPanel" aria-selected="false">Assignacions</button>
-      <button id="tab-classroom" class="portal-tab" type="button" data-tab="classroom" role="tab" aria-controls="classroomPanel" aria-selected="false">Gestió d'aula</button>
       <button id="tab-results" class="portal-tab" type="button" data-tab="results" role="tab" aria-controls="resultsPanel" aria-selected="false">Resultats</button>
     </div>
-
-    <section id="classroomPanel" class="portal-tabpanel hidden" data-tab-panel="classroom" role="tabpanel" aria-labelledby="tab-classroom">
-      <section class="panel card">
-        <div class="portal-section-header">
-          <div>
-            <p class="portal-section-title">Participació equilibrada</p>
-            <h2>Selector aleatori d'alumnes</h2>
-            <p class="portal-muted">Recorre tota la llista sense repetir fins a reiniciar la ronda.</p>
-          </div>
-          <div class="portal-actions">
-            <button id="classroomResetPicks" class="btn-ghost" type="button">Reinicia ronda</button>
-          </div>
-        </div>
-
-        <div class="classroom-random-grid">
-          <label>
-            <span class="portal-field-label">Classe</span>
-            <select id="classroomClassSelect" class="input"></select>
-          </label>
-          <div class="classroom-random-actions">
-            <button id="classroomPickStudent" class="btn-primary" type="button">Tria un alumne</button>
-            <p id="classroomPickResult" class="classroom-pick-result portal-muted" role="status" aria-live="polite"></p>
-          </div>
-        </div>
-
-        <div id="classroomPickHistory" class="classroom-history"></div>
-      </section>
-
-      <section class="panel card">
-        <div class="portal-section-header">
-          <div>
-            <p class="portal-section-title">Control del temps</p>
-            <h2>Temporitzador de classe</h2>
-            <p class="portal-muted">Marca els minuts d'una activitat, pausa quan calgui i reinicia fàcilment.</p>
-          </div>
-          <div class="portal-actions">
-            <button id="classroomTimerReset" class="btn-ghost" type="button">Reinicia</button>
-          </div>
-        </div>
-
-        <div class="classroom-timer-grid">
-          <label>
-            <span class="portal-field-label">Minuts</span>
-            <input id="classroomTimerMinutes" class="input" type="number" min="1" max="120" value="5" />
-          </label>
-          <div class="classroom-timer-controls">
-            <div class="classroom-timer-display" aria-live="polite">
-              <p id="classroomTimerDisplay" class="classroom-timer-time">05:00</p>
-              <p id="classroomTimerStatus" class="portal-muted" style="margin:0">Preparat</p>
-            </div>
-            <div class="classroom-timer-buttons">
-              <button id="classroomTimerToggle" class="btn-primary" type="button">Inicia</button>
-            </div>
-          </div>
-        </div>
-
-        <div class="classroom-timer-bar" aria-hidden="true">
-          <span id="classroomTimerProgress"></span>
-        </div>
-      </section>
-
-      <section class="panel card">
-        <div class="portal-section-header">
-          <div>
-            <p class="portal-section-title">Seguiment ràpid</p>
-            <h2>Notes de classe</h2>
-            <p class="portal-muted">Anota incidències, encàrrecs o idees sense sortir del gestor.</p>
-          </div>
-          <div class="portal-actions">
-            <button id="classroomNotesSave" class="btn-secondary" type="button">Desa</button>
-          </div>
-        </div>
-
-        <div class="portal-form portal-form--stack">
-          <label>
-            <span class="portal-field-label">Notes ràpides</span>
-            <textarea id="classroomNotes" class="input" rows="5" placeholder="Puntua la participació, recordatoris, acord amb alumnat..."></textarea>
-            <span id="classroomNotesStatus" class="portal-muted" role="status" aria-live="polite"></span>
-          </label>
-        </div>
-      </section>
-    </section>
 
     <section id="classesPanel" class="portal-tabpanel hidden" data-tab-panel="classes" role="tabpanel" aria-labelledby="tab-classes">
       <section class="panel card">
@@ -273,27 +190,39 @@
               <p id="moduleConfigNotice" class="portal-muted hidden"></p>
             </div>
           </div>
-          <div class="portal-form portal-form--three">
-            <label>
-              <span class="portal-field-label">Preguntes</span>
-              <input class="input" name="count" type="number" min="1" max="200" value="20" />
+          <div class="portal-quiz-options" aria-label="Opcions comunes de la prova">
+            <label class="portal-quiz-chip">
+              <span>Preguntes</span>
+              <select class="input" name="count" aria-label="Nombre de preguntes">
+                <option selected>10</option>
+                <option>20</option>
+                <option>30</option>
+                <option>50</option>
+              </select>
             </label>
-            <label>
-              <span class="portal-field-label">Temps (minuts)</span>
-              <input class="input" name="time" type="number" min="0" max="180" value="0" />
+            <label class="portal-quiz-chip">
+              <span>Temps (min)</span>
+              <select class="input" name="time" aria-label="Temps màxim en minuts">
+                <option value="0" selected>Sense límit</option>
+                <option>5</option>
+                <option>10</option>
+                <option>15</option>
+                <option>20</option>
+              </select>
             </label>
-            <label id="assignmentLevelField">
-              <span class="portal-field-label">Nivell (1-4)</span>
-              <input id="assignmentLevelInput" class="input" name="level" type="number" min="1" max="4" value="1" />
+            <label id="assignmentLevelField" class="portal-quiz-chip">
+              <span>Nivell (1–4)</span>
+              <select id="assignmentLevelInput" class="input" name="level" aria-label="Nivell de dificultat">
+                <option selected>1</option>
+                <option>2</option>
+                <option>3</option>
+                <option>4</option>
+              </select>
             </label>
           </div>
           <label>
             <span class="portal-field-label">Data límit (opcional)</span>
             <input class="input" name="due_at" type="datetime-local" />
-          </label>
-          <label class="portal-form--stack">
-            <span class="portal-field-label">Notes internes</span>
-            <textarea class="input" name="notes" rows="3" placeholder="Anota criteris o instruccions per recordar-les"></textarea>
           </label>
           <div class="portal-actions">
             <button class="btn-primary" type="submit">Publica la prova</button>

--- a/portal/supabase-portal.js
+++ b/portal/supabase-portal.js
@@ -34,19 +34,6 @@ const state = {
   submissions: [],
   activeSubmissionId: null,
   focusedResultAssignmentId: null,
-  classroom: {
-    selectedClassId: '',
-    pools: new Map(),
-    lastPick: '',
-    timer: {
-      durationSeconds: 300,
-      remainingSeconds: 300,
-      running: false,
-      endsAt: null,
-      handle: null,
-    },
-    notes: '',
-  },
   assignmentDraft: {
     moduleId: '',
     options: {},
@@ -104,24 +91,9 @@ const elements = {
   refreshResults: document.getElementById('refreshResults'),
   resultsClassFilter: document.getElementById('resultsClassFilter'),
   resultsAssignmentFilter: document.getElementById('resultsAssignmentFilter'),
-  classroomClassSelect: document.getElementById('classroomClassSelect'),
-  classroomPickButton: document.getElementById('classroomPickStudent'),
-  classroomPickResult: document.getElementById('classroomPickResult'),
-  classroomPickHistory: document.getElementById('classroomPickHistory'),
-  classroomResetPicks: document.getElementById('classroomResetPicks'),
-  classroomTimerMinutes: document.getElementById('classroomTimerMinutes'),
-  classroomTimerToggle: document.getElementById('classroomTimerToggle'),
-  classroomTimerReset: document.getElementById('classroomTimerReset'),
-  classroomTimerDisplay: document.getElementById('classroomTimerDisplay'),
-  classroomTimerStatus: document.getElementById('classroomTimerStatus'),
-  classroomTimerProgress: document.getElementById('classroomTimerProgress'),
-  classroomNotes: document.getElementById('classroomNotes'),
-  classroomNotesStatus: document.getElementById('classroomNotesStatus'),
-  classroomNotesSave: document.getElementById('classroomNotesSave'),
 };
 
 let previewChannel = null;
-let notesSaveTimeout = null;
 
 
 function getNested(source, keys, fallback) {
@@ -450,7 +422,6 @@ function formatDateTime(value, options = { dateStyle: 'short', timeStyle: 'short
 function renderClassOptions() {
   const selects = [
     { node: elements.assignmentClassSelect, stateAccessor: null },
-    { node: elements.classroomClassSelect, stateAccessor: 'classroom.selectedClassId' },
   ];
 
   const options = state.classes.map((cls) => ({
@@ -523,264 +494,6 @@ function getClassById(classId) {
   return state.classes.find((cls) => cls.id === classId) || null;
 }
 
-function ensureClassroomSelection() {
-  if (!Array.isArray(state.classes) || state.classes.length === 0) {
-    state.classroom.selectedClassId = '';
-    return;
-  }
-  if (!state.classroom.selectedClassId) {
-    state.classroom.selectedClassId = state.classes[0].id;
-    return;
-  }
-  const exists = state.classes.some((cls) => cls.id === state.classroom.selectedClassId);
-  if (!exists) {
-    state.classroom.selectedClassId = state.classes[0].id;
-  }
-}
-
-function getClassroomPool(classId) {
-  const cls = getClassById(classId);
-  const roster = cls && Array.isArray(cls.students) ? cls.students : [];
-  const signature = roster.join('||');
-  const existing = state.classroom.pools.get(classId);
-  if (!existing || existing.signature !== signature) {
-    state.classroom.pools.set(classId, {
-      remaining: [...roster],
-      history: [],
-      signature,
-    });
-  }
-  return state.classroom.pools.get(classId);
-}
-
-function resetClassroomPool(classId) {
-  if (!classId) return;
-  const cls = getClassById(classId);
-  const roster = cls && Array.isArray(cls.students) ? cls.students : [];
-  state.classroom.pools.set(classId, {
-    remaining: [...roster],
-    history: [],
-    signature: roster.join('||'),
-  });
-  state.classroom.lastPick = '';
-}
-
-function pickRandomStudent() {
-  const classId = state.classroom.selectedClassId;
-  const pool = getClassroomPool(classId || '');
-  const roster = pool ? pool.remaining : [];
-  if (!classId || !pool || !Array.isArray(roster) || roster.length === 0) {
-    state.classroom.lastPick = classId ? 'Cap alumne pendent' : 'Afegeix alumnes a la classe';
-    renderClassroomRandom();
-    return;
-  }
-  const index = Math.floor(Math.random() * roster.length);
-  const [selected] = roster.splice(index, 1);
-  pool.history.unshift(selected);
-  state.classroom.lastPick = selected;
-  renderClassroomRandom();
-}
-
-function renderClassroomRandom() {
-  ensureClassroomSelection();
-  const select = elements.classroomClassSelect;
-  const pool = getClassroomPool(state.classroom.selectedClassId || '');
-  const remaining = pool && Array.isArray(pool.remaining) ? pool.remaining.length : 0;
-  const history = pool && Array.isArray(pool.history) ? pool.history : [];
-
-  if (select) {
-    select.value = state.classroom.selectedClassId || '';
-  }
-  if (elements.classroomPickResult) {
-    elements.classroomPickResult.textContent = state.classroom.lastPick || "Fes clic per triar un alumne a l'atzar";
-  }
-  if (elements.classroomPickHistory) {
-    elements.classroomPickHistory.innerHTML = '';
-    if (history.length === 0) {
-      const chip = document.createElement('span');
-      chip.className = 'portal-chip portal-chip--muted';
-      chip.textContent = 'Encara no hi ha torns assignats';
-      elements.classroomPickHistory.appendChild(chip);
-    } else {
-      history.slice(0, 12).forEach((name) => {
-        const chip = document.createElement('span');
-        chip.className = 'portal-chip';
-        chip.textContent = name;
-        elements.classroomPickHistory.appendChild(chip);
-      });
-    }
-    if (remaining > 0) {
-      const chip = document.createElement('span');
-      chip.className = 'portal-chip portal-chip--muted';
-      chip.textContent = `${remaining} pendent(s)`;
-      elements.classroomPickHistory.appendChild(chip);
-    }
-  }
-}
-
-function clamp(value, min, max) {
-  return Math.min(Math.max(value, min), max);
-}
-
-function formatSeconds(totalSeconds) {
-  if (!Number.isFinite(totalSeconds)) return '00:00';
-  const seconds = Math.max(0, Math.round(totalSeconds));
-  const mins = Math.floor(seconds / 60)
-    .toString()
-    .padStart(2, '0');
-  const secs = (seconds % 60).toString().padStart(2, '0');
-  return `${mins}:${secs}`;
-}
-
-function clearClassroomTimerHandle() {
-  if (state.classroom.timer.handle) {
-    clearInterval(state.classroom.timer.handle);
-    state.classroom.timer.handle = null;
-  }
-}
-
-function syncTimerDurationFromInput({ updateRemaining = false } = {}) {
-  const minutes = elements.classroomTimerMinutes
-    ? clamp(Number.parseInt(elements.classroomTimerMinutes.value, 10) || 0, 1, 120)
-    : 5;
-  const durationSeconds = minutes * 60;
-  state.classroom.timer.durationSeconds = durationSeconds;
-  if (updateRemaining || !state.classroom.timer.running) {
-    state.classroom.timer.remainingSeconds = durationSeconds;
-  }
-  renderClassroomTimer();
-}
-
-function renderClassroomTimer() {
-  const timer = state.classroom.timer;
-  if (elements.classroomTimerMinutes && !elements.classroomTimerMinutes.matches(':focus')) {
-    elements.classroomTimerMinutes.value = Math.max(1, Math.round((timer.durationSeconds || 60) / 60));
-  }
-  if (elements.classroomTimerDisplay) {
-    elements.classroomTimerDisplay.textContent = formatSeconds(timer.remainingSeconds);
-  }
-  if (elements.classroomTimerToggle) {
-    elements.classroomTimerToggle.textContent = timer.running ? 'Pausa' : timer.remainingSeconds <= 0 ? 'Reinicia' : 'Inicia';
-  }
-  if (elements.classroomTimerStatus) {
-    elements.classroomTimerStatus.textContent = timer.running
-      ? 'Compte enrere en marxa'
-      : timer.remainingSeconds <= 0
-        ? 'Temps completat'
-        : 'Preparat';
-  }
-  if (elements.classroomTimerProgress) {
-    const total = timer.durationSeconds || 1;
-    const ratio = clamp(timer.remainingSeconds / total, 0, 1);
-    elements.classroomTimerProgress.style.transform = `scaleX(${ratio})`;
-  }
-}
-
-function tickClassroomTimer() {
-  const timer = state.classroom.timer;
-  if (!timer.running || !timer.endsAt) return;
-  const remainingMs = Math.max(0, timer.endsAt - Date.now());
-  timer.remainingSeconds = Math.round(remainingMs / 1000);
-  if (timer.remainingSeconds <= 0) {
-    timer.running = false;
-    timer.endsAt = null;
-    clearClassroomTimerHandle();
-  }
-  renderClassroomTimer();
-}
-
-function startClassroomTimer() {
-  const timer = state.classroom.timer;
-  if (timer.running) return;
-  if (timer.remainingSeconds <= 0) {
-    timer.remainingSeconds = timer.durationSeconds || 60;
-  }
-  timer.running = true;
-  timer.endsAt = Date.now() + timer.remainingSeconds * 1000;
-  clearClassroomTimerHandle();
-  timer.handle = setInterval(tickClassroomTimer, 500);
-  renderClassroomTimer();
-}
-
-function pauseClassroomTimer() {
-  const timer = state.classroom.timer;
-  timer.running = false;
-  timer.endsAt = null;
-  clearClassroomTimerHandle();
-  renderClassroomTimer();
-}
-
-function resetClassroomTimer() {
-  const timer = state.classroom.timer;
-  timer.running = false;
-  timer.endsAt = null;
-  clearClassroomTimerHandle();
-  syncTimerDurationFromInput({ updateRemaining: true });
-}
-
-function loadClassroomNotes() {
-  const classId = state.classroom.selectedClassId;
-  const storageKey = classId ? `fq_classroom_notes_${classId}` : null;
-  if (!storageKey) {
-    state.classroom.notes = '';
-    return;
-  }
-  try {
-    state.classroom.notes = localStorage.getItem(storageKey) || '';
-  } catch (error) {
-    console.warn('No s\'han pogut llegir les notes locals', error);
-    state.classroom.notes = '';
-  }
-}
-
-function saveClassroomNotes() {
-  const classId = state.classroom.selectedClassId;
-  const storageKey = classId ? `fq_classroom_notes_${classId}` : null;
-  if (!storageKey) return;
-  try {
-    localStorage.setItem(storageKey, state.classroom.notes || '');
-    if (elements.classroomNotesStatus) {
-      elements.classroomNotesStatus.textContent = 'Notes desades localment';
-    }
-  } catch (error) {
-    console.warn('No s\'han pogut desar les notes locals', error);
-    if (elements.classroomNotesStatus) {
-      elements.classroomNotesStatus.textContent = 'No s\'ha pogut desar (consulta permisos del navegador)';
-    }
-  }
-}
-
-function renderClassroomNotes() {
-  if (elements.classroomNotes) {
-    elements.classroomNotes.value = state.classroom.notes || '';
-    elements.classroomNotes.disabled = !state.classroom.selectedClassId;
-  }
-  if (elements.classroomNotesStatus) {
-    elements.classroomNotesStatus.textContent = state.classroom.selectedClassId
-      ? 'Es desen al navegador per a aquesta classe'
-      : 'Crea una classe per activar les notes';
-  }
-}
-
-function handleClassroomNotesInput() {
-  if (!elements.classroomNotes) return;
-  state.classroom.notes = elements.classroomNotes.value;
-  if (notesSaveTimeout) {
-    clearTimeout(notesSaveTimeout);
-  }
-  notesSaveTimeout = setTimeout(() => {
-    saveClassroomNotes();
-    notesSaveTimeout = null;
-  }, 600);
-}
-
-function renderClassroomTools() {
-  ensureClassroomSelection();
-  loadClassroomNotes();
-  renderClassroomRandom();
-  renderClassroomTimer();
-  renderClassroomNotes();
-}
 
 
 function resolveModuleInfo(moduleOrId) {
@@ -1764,7 +1477,6 @@ function renderAll() {
   renderAssignments();
   buildResultsFilters();
   renderResults();
-  renderClassroomTools();
 }
 
 async function updateRoster(classId, rawValue, feedbackNode) {
@@ -1987,8 +1699,6 @@ async function createAssignment(formData) {
   const storedLevel = usesLevels ? level : 0;
   const levelLabel = usesLevels ? null : moduleFreeLevelLabel(module);
   const dueAtRaw = readFormValue(formData, 'due_at').trim();
-  const notesValue = readFormValue(formData, 'notes').trim();
-  const notes = notesValue ? notesValue : null;
   const moduleOptions = collectModuleOptions();
   const questionSet = Array.isArray(state.assignmentDraft.questionSet)
     ? state.assignmentDraft.questionSet.map((question) => {
@@ -2032,7 +1742,6 @@ async function createAssignment(formData) {
       quiz_config: quizConfig,
       status: 'published',
       due_at: dueAtRaw ? new Date(dueAtRaw).toISOString() : null,
-      notes,
     };
     const { error } = await client.from('assignments').insert(payload);
     if (error) throw error;
@@ -2380,49 +2089,6 @@ function setupEventListeners() {
   }
   if (elements.resultsAssignmentFilter) {
     elements.resultsAssignmentFilter.addEventListener('change', renderResults);
-  }
-  if (elements.classroomClassSelect) {
-    elements.classroomClassSelect.addEventListener('change', () => {
-      state.classroom.selectedClassId = elements.classroomClassSelect.value || '';
-      resetClassroomPool(state.classroom.selectedClassId);
-      loadClassroomNotes();
-      renderClassroomTools();
-    });
-  }
-  if (elements.classroomPickButton) {
-    elements.classroomPickButton.addEventListener('click', pickRandomStudent);
-  }
-  if (elements.classroomResetPicks) {
-    elements.classroomResetPicks.addEventListener('click', () => {
-      resetClassroomPool(state.classroom.selectedClassId);
-      renderClassroomRandom();
-    });
-  }
-  if (elements.classroomTimerMinutes) {
-    const handler = () => syncTimerDurationFromInput({ updateRemaining: !state.classroom.timer.running });
-    elements.classroomTimerMinutes.addEventListener('input', handler);
-    elements.classroomTimerMinutes.addEventListener('change', handler);
-  }
-  if (elements.classroomTimerToggle) {
-    elements.classroomTimerToggle.addEventListener('click', () => {
-      if (state.classroom.timer.running) {
-        pauseClassroomTimer();
-      } else {
-        startClassroomTimer();
-      }
-    });
-  }
-  if (elements.classroomTimerReset) {
-    elements.classroomTimerReset.addEventListener('click', resetClassroomTimer);
-  }
-  if (elements.classroomNotes) {
-    elements.classroomNotes.addEventListener('input', handleClassroomNotesInput);
-  }
-  if (elements.classroomNotesSave) {
-    elements.classroomNotesSave.addEventListener('click', () => {
-      state.classroom.notes = elements.classroomNotes ? elements.classroomNotes.value : state.classroom.notes;
-      saveClassroomNotes();
-    });
   }
   window.addEventListener('message', handlePreviewMessage);
   window.addEventListener('storage', handlePreviewStorageMessage);


### PR DESCRIPTION
### Motivation
- Simplify the teacher portal by removing the classroom management toolset (random picker, timer, and notes) and declutter the UI.
- Replace free-form numeric inputs for assignment quiz options with curated select controls for a clearer and more consistent experience.
- Update homepage copy and remove the standalone challenges entry to match the simplified navigation.

### Description
- Updated `app.html` to adjust the hero copy and remove the `challengesEntrySection` block so the homepage no longer advertises the removed standalone challenges entry.
- Removed the classroom tab and the entire classroom tools panel from `portal/supabase-portal.html`, and refactored the assignment creation form by replacing free `/count`, `/time`, and `/level` numeric inputs with a new `portal-quiz-options` block using `select` controls and `portal-quiz-chip` wrappers.
- Reworked styles in `portal/portal.css` by deleting legacy `.classroom-*` rules and adding `.portal-quiz-options` and `.portal-quiz-chip` styles (including responsive behavior) to support the new assignment option UI.
- Simplified `portal/supabase-portal.js` by removing the `classroom` state and all classroom-related DOM element references, functions, and event listeners, and by updating `createAssignment` to rely on the new select inputs and removing the `notes` payload.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a444e8ab8e0832db926bae2f715a667)