### PR TITLE
Add 'competencial' math module and UI; remove classroom tools and update portal quiz options

### DIFF
--- a/app.html
+++ b/app.html
@@ -271,11 +271,10 @@
         <section class="fq-home-landing" aria-labelledby="focusQuizHomeTitle">
           <div class="fq-home-landing__content">
             <p class="portal-section-title">FocusQuiz · Plataforma educativa</p>
-            <h2 id="focusQuizHomeTitle" class="title">Aprenentatge, reptes i entrenament cognitiu en un sol espai</h2>
-            <p class="subtitle">Crea proves, practica continguts, entra a l'aula amb codi, juga reptes d'aprenentatge i accedeix a FocusMind des del menú superior quan vulguis entrenar atenció, memòria i flexibilitat mental.</p>
+            <h2 id="focusQuizHomeTitle" class="title">Aprenentatge i entrenament cognitiu en un sol espai</h2>
+            <p class="subtitle">Crea proves, practica continguts, entra a l'aula amb codi i accedeix a FocusMind des del menú superior quan vulguis entrenar atenció, memòria i flexibilitat mental.</p>
             <div class="fq-home-landing__chips" aria-label="Àrees disponibles">
               <span>📚 Mòduls d'estudi</span>
-              <span>🎯 Reptes</span>
               <span>🧠 FocusMind</span>
               <span>👥 Aula</span>
               <span>🤖 Tutor virtual</span>
@@ -297,18 +296,6 @@
           <div class="tutor-actions">
           </div>
         </div>
-
-
-        <section id="challengesEntrySection" class="panel card challenge-entry" aria-labelledby="challengesEntryTitle">
-          <div>
-            <p class="portal-section-title">Reptes</p>
-            <h2 id="challengesEntryTitle">Vols jugar als reptes Focus?</h2>
-            <p class="subtitle">Entra a la zona de jocs i tria el repte disponible. Ara mateix: <strong>Joc de la corda</strong>.</p>
-          </div>
-          <div class="challenge-entry__actions">
-            <a class="pill" href="reptes.html">Entrar a Reptes →</a>
-          </div>
-        </section>
 
 
         <section id="classSection" class="panel card home-live-cta home-class-cta" aria-labelledby="homeClassTitle">

--- a/main.js
+++ b/main.js
@@ -907,6 +907,25 @@ function openConfig(moduleId){
         <span class="subtitle">Escriu <b>només el nombre</b> (la unitat ja surt a l'enunciat).</span>
       </div>
     `;
+  } else if(pendingModule.id === 'competencial'){
+    wrap.innerHTML = `
+      <div class="section-title">Problemes competencials · Subtemes</div>
+      <div class="controls">
+        <div class="group" role="group" aria-label="Subtemes de problemes competencials">
+          <label class="toggle"><input class="check" type="radio" name="competencial-sub" value="mix" checked> Barrejats</label>
+          <label class="toggle"><input class="check" type="radio" name="competencial-sub" value="money"> Compres i diners</label>
+          <label class="toggle"><input class="check" type="radio" name="competencial-sub" value="time"> Temps i horaris</label>
+          <label class="toggle"><input class="check" type="radio" name="competencial-sub" value="units"> Mesures i unitats</label>
+          <label class="toggle"><input class="check" type="radio" name="competencial-sub" value="proportion"> Proporcionalitat</label>
+          <label class="toggle"><input class="check" type="radio" name="competencial-sub" value="graphs"> Gràfics i taules</label>
+          <label class="toggle"><input class="check" type="radio" name="competencial-sub" value="geometry"> Geometria aplicada</label>
+          <label class="toggle"><input class="check" type="radio" name="competencial-sub" value="percent"> Percentatges</label>
+          <label class="toggle"><input class="check" type="radio" name="competencial-sub" value="equations"> Equacions en context</label>
+          <label class="toggle"><input class="check" type="radio" name="competencial-sub" value="multistep"> Problemes multistep</label>
+        </div>
+      </div>
+      <div class="subtitle">Cada subtema comença amb 3 problemes de mostra. Escriu només el nombre; la unitat apareix com a pista.</div>
+    `;
   } else if(pendingModule.id === 'coord'){
     wrap.innerHTML = `
       <div class="section-title">Coordenades cartesianes · Subtemes</div>
@@ -1090,6 +1109,8 @@ function collectConfigValues(){
   } else if(pendingModule.id==='units'){
     options.sub = document.querySelector('input[name="units-sub"]:checked')?.value || 'length';
     options.round = parseInt($('#units-round').value || '2');
+  } else if(pendingModule.id==='competencial'){
+    options.sub = document.querySelector('input[name="competencial-sub"]:checked')?.value || 'mix';
   } else if(pendingModule.id==='coord'){
     options.sub = document.querySelector('input[name="coord-sub"]:checked')?.value || 'read';
   } else if(pendingModule.id==='eq'){

--- a/math.js
+++ b/math.js
@@ -1016,6 +1016,96 @@ function genPercent(level, opts = {}){
   return { type:'percent-discount', text:`Descompte del ${off}% sobre ${n} → preu final = ?`, answer: ans };
 }
 
+/* ===== Problemes competencials ===== */
+
+const COMPETENCIAL_SUBTHEMES = ['mix','money','time','units','proportion','graphs','geometry','percent','equations','multistep'];
+
+const COMPETENCIAL_BANK = {
+  money: [
+    { level: 1, text: 'Una llibreta costa 2,50 €. Si en compres 4, quant pagaràs?', answer: 10, unit: '€' },
+    { level: 2, text: 'Una entrada val 6 €. Compreu 4 entrades i pagueu amb 30 €. Quin canvi us tornen?', answer: 6, unit: '€' },
+    { level: 3, text: 'Un grup compra 3 entrepans de 4 € i 2 aigües de 1,50 €. Quant paga en total?', answer: 15, unit: '€' },
+  ],
+  time: [
+    { level: 1, text: 'Una activitat comença a les 9:15 i acaba a les 10:05. Quants minuts dura?', answer: 50, unit: 'min' },
+    { level: 2, text: 'Un tren surt a les 16:40 i arriba a les 18:10. Quants minuts dura el trajecte?', answer: 90, unit: 'min' },
+    { level: 3, text: 'Una pel·lícula comença a les 17:20 i dura 1 h 35 min. Quants minuts passen fins que acaba?', answer: 95, unit: 'min' },
+  ],
+  units: [
+    { level: 1, text: 'Una corda fa 2,5 m. Quants centímetres són?', answer: 250, unit: 'cm' },
+    { level: 2, text: 'Una ampolla té 1,5 L d’aigua. Quants mil·lilitres són?', answer: 1500, unit: 'ml' },
+    { level: 3, text: 'Un camí fa 2,4 km i ja n’has recorregut 850 m. Quants metres et falten?', answer: 1550, unit: 'm' },
+  ],
+  proportion: [
+    { level: 1, text: 'Una recepta per a 4 persones necessita 300 g de pasta. Quants grams calen per a 8 persones?', answer: 600, unit: 'g' },
+    { level: 2, text: 'Un cotxe recorre 180 km en 3 hores. Quants quilòmetres fa en 1 hora si manté el ritme?', answer: 60, unit: 'km' },
+    { level: 3, text: 'En un mapa, 1 cm representa 5 km. Si dues ciutats estan separades 7 cm al mapa, quants km són en realitat?', answer: 35, unit: 'km' },
+  ],
+  graphs: [
+    {
+      level: 1,
+      text: 'Segons la taula, quin dia es van vendre més entrades? Escriu el nombre d’entrades.',
+      html: '<table class="mini-table"><tr><th>Dilluns</th><th>Dimarts</th><th>Dimecres</th></tr><tr><td>35</td><td>42</td><td>38</td></tr></table>',
+      answer: 42,
+      unit: 'entrades',
+    },
+    {
+      level: 2,
+      text: 'Segons la taula, quina diferència hi ha entre la temperatura més alta i la més baixa?',
+      html: '<table class="mini-table"><tr><th>Dilluns</th><th>Dimarts</th><th>Dimecres</th></tr><tr><td>18 °C</td><td>24 °C</td><td>21 °C</td></tr></table>',
+      answer: 6,
+      unit: '°C',
+    },
+    {
+      level: 3,
+      text: 'Segons la taula, quina és la mitjana de llibres llegits?',
+      html: '<table class="mini-table"><tr><th>Aina</th><th>Nil</th><th>Ona</th><th>Marc</th></tr><tr><td>3</td><td>5</td><td>4</td><td>8</td></tr></table>',
+      answer: 5,
+      unit: 'llibres',
+    },
+  ],
+  geometry: [
+    { level: 1, text: 'Un jardí rectangular fa 8 m de llarg i 5 m d’ample. Quants metres de tanca calen per envoltar-lo?', answer: 26, unit: 'm' },
+    { level: 2, text: 'Una paret fa 4 m d’ample i 3 m d’alt. Quina superfície té?', answer: 12, unit: 'm²' },
+    { level: 3, text: 'Una caixa rectangular fa 6 cm de llarg, 4 cm d’ample i 5 cm d’alt. Quin volum té?', answer: 120, unit: 'cm³' },
+  ],
+  percent: [
+    { level: 1, text: 'Una bicicleta val 200 € i té un descompte del 15%. Quants euros t’estalvies?', answer: 30, unit: '€' },
+    { level: 2, text: 'Una dessuadora val 80 € i té un descompte del 20%. Quin és el preu final?', answer: 64, unit: '€' },
+    { level: 3, text: 'En una classe de 25 alumnes, el 40% han triat bàsquet. Quants alumnes són?', answer: 10, unit: 'alumnes' },
+  ],
+  equations: [
+    { level: 1, text: 'La Laia té alguns cromos. Si en rep 5 i acaba amb 18, quants cromos tenia al principi?', answer: 13, unit: 'cromos' },
+    { level: 2, text: 'Tres entrades iguals costen 24 €. Quant costa una entrada?', answer: 8, unit: '€' },
+    { level: 3, text: 'Un nombre multiplicat per 4 i després sumat amb 6 dona 34. Quin és el nombre?', answer: 7, unit: '' },
+  ],
+  multistep: [
+    { level: 2, text: 'Una sortida costa 240 € d’autocar per a 48 alumnes i 5 € d’entrada per alumne. Quant paga cada alumne en total?', answer: 10, unit: '€' },
+    { level: 3, text: 'Una família compra 2 adults a 9 € i 3 infants a 6 €. Si paga amb 50 €, quin canvi rep?', answer: 14, unit: '€' },
+    { level: 4, text: 'Per pintar 38 m², cada pot cobreix 12 m² i costa 18 €. Quants euros costaran els pots necessaris?', answer: 72, unit: '€' },
+  ],
+};
+
+function genCompetencial(level, opts = {}) {
+  const requested = COMPETENCIAL_SUBTHEMES.includes(opts.sub) ? opts.sub : 'mix';
+  const subthemes = requested === 'mix'
+    ? COMPETENCIAL_SUBTHEMES.filter((item) => item !== 'mix')
+    : [requested];
+  const pool = subthemes
+    .flatMap((sub) => (COMPETENCIAL_BANK[sub] || []).map((problem) => ({ ...problem, sub })))
+    .filter((problem) => !Number.isFinite(problem.level) || problem.level <= clamp(level, 1, 4) + 1);
+  const problem = choice(pool.length ? pool : Object.values(COMPETENCIAL_BANK).flat());
+  const unitHint = problem.unit ? ` <span class="chip">Resposta en ${problem.unit}</span>` : '';
+  return {
+    type: 'competencial',
+    text: problem.text,
+    html: problem.html || '',
+    answer: problem.answer,
+    meta: { subtheme: problem.sub, unit: problem.unit || '' },
+    title: `${problem.text}${unitHint}`,
+  };
+}
+
 /* ===== Equacions ===== */
 
 function randCoef(rangeKey){
@@ -1601,6 +1691,7 @@ function generateLogarithmicFunction(aspect, difficulty, level) {
     { id:'coord', name:'Coordenades cartesianes', desc:'Col·loca punts als quadrants i llegeix coordenades.', gen: genCoordinates, category:'math' },
     { id:'stats', name:'Estadística bàsica', desc:'Mitjana/mediana/moda, rang/desviació i gràfics.', gen: genStats, category:'math' },
     { id:'units', name:'Unitats i conversions', desc:'Longitud, massa, volum, superfície i temps.', gen: genUnits, category:'math' },
+    { id:'competencial', name:'Problemes competencials', desc:'Situacions reals amb diners, temps, unitats, gràfics, geometria, percentatges i raonament multistep.', gen: genCompetencial, category:'math' },
     { id:'eq',    name:'Equacions', desc:'1r grau, 2n grau, sistemes, fraccions i parèntesis.', gen: genEq, category:'math' },
     { id:'func',  name:'Estudi de funcions', desc:'Tipus, domini, punts de tall, simetria, límits, extrems i monotonia.', gen: genFunctions, category:'math' }
 ];

--- a/portal/module-config.js
+++ b/portal/module-config.js
@@ -109,6 +109,19 @@ const unitsSubthemes = [
   { value: 'time', label: 'Temps' },
 ];
 
+const competencialSubthemes = [
+  { value: 'mix', label: 'Barrejats' },
+  { value: 'money', label: 'Compres i diners' },
+  { value: 'time', label: 'Temps i horaris' },
+  { value: 'units', label: 'Mesures i unitats' },
+  { value: 'proportion', label: 'Proporcionalitat' },
+  { value: 'graphs', label: 'Gràfics i taules' },
+  { value: 'geometry', label: 'Geometria aplicada' },
+  { value: 'percent', label: 'Percentatges' },
+  { value: 'equations', label: 'Equacions en context' },
+  { value: 'multistep', label: 'Problemes multistep' },
+];
+
 const equationFormats = [
   { value: 'normal', label: 'Normals' },
   { value: 'frac', label: 'Amb fraccions' },
@@ -683,6 +696,49 @@ const unitsDefinition = {
   },
 };
 
+function competencialDefaults() {
+  return { sub: 'mix' };
+}
+
+function competencialNormalize(options = {}) {
+  const allowed = competencialSubthemes.map((item) => item.value);
+  const sub = allowed.includes(options.sub) ? options.sub : 'mix';
+  return { sub };
+}
+
+const competencialDefinition = {
+  defaults: competencialDefaults,
+  normalize: competencialNormalize,
+  render(options = {}) {
+    const opts = competencialNormalize(options);
+    const radios = competencialSubthemes
+      .map((item) => `
+        <label class="toggle"><input class="check" type="radio" name="competencial-sub" value="${item.value}" ${CHECKED(opts.sub === item.value)}> ${item.label}</label>
+      `)
+      .join('');
+    return createContainer('competencial', `
+      <div class="section-title">Subtemes competencials</div>
+      <div class="controls">
+        <div class="group" role="group" aria-label="Subtemes de problemes competencials">
+          ${radios}
+        </div>
+      </div>
+      <p class="subtitle">Cada subtema inclou 3 problemes de mostra. L'opció “Barrejats” combina tots els subtemes.</p>
+    `);
+  },
+  collect(card) {
+    const scope = safeQuery(card, '[data-module-config="competencial"]');
+    if (!scope) return competencialDefaults();
+    const sub = getCheckedValue(scope, 'input[name="competencial-sub"]:checked', 'mix');
+    return competencialNormalize({ sub });
+  },
+  summarize(options = {}) {
+    const opts = competencialNormalize(options);
+    const subInfo = competencialSubthemes.find((item) => item.value === opts.sub);
+    return `Subtema: ${subInfo ? subInfo.label : 'Barrejats'}`;
+  },
+};
+
 function equationsDefaults() {
   return {
     format: 'normal',
@@ -1238,6 +1294,7 @@ export const MODULE_OPTION_DEFINITIONS = {
   coord: coordDefinition,
   stats: statsDefinition,
   units: unitsDefinition,
+  competencial: competencialDefinition,
   eq: equationsDefinition,
   func: functionsDefinition,
   'cat-ort': ortografiaDefinition,

--- a/portal/modules-data.js
+++ b/portal/modules-data.js
@@ -15,6 +15,12 @@ export const MODULES = [
   { id: 'coord', name: 'Coordenades cartesianes', desc: 'Col·loca punts als quadrants i llegeix coordenades.', category: 'math' },
   { id: 'stats', name: 'Estadística bàsica', desc: 'Mitjana/mediana/moda, rang/desviació i gràfics.', category: 'math' },
   { id: 'units', name: 'Unitats i conversions', desc: 'Longitud, massa, volum, superfície i temps.', category: 'math' },
+  {
+    id: 'competencial',
+    name: 'Problemes competencials',
+    desc: 'Situacions reals amb diners, temps, unitats, gràfics, geometria, percentatges i raonament multistep.',
+    category: 'math',
+  },
   { id: 'eq', name: 'Equacions', desc: '1r grau, 2n grau, sistemes, fraccions i parèntesis.', category: 'math' },
   { id: 'func', name: 'Estudi de funcions', desc: 'Tipus, domini, punts de tall, simetria, límits, extrems i monotonia.', category: 'math' },
   {

--- a/portal/portal.css
+++ b/portal/portal.css
@@ -2609,91 +2609,56 @@
   grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
 }
 
-.classroom-random-grid {
-  display: grid;
-  gap: 1rem;
-  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
-  align-items: end;
-}
-
-.classroom-random-actions {
-  display: grid;
-  gap: 0.5rem;
-  align-content: center;
-}
-
-.classroom-pick-result {
-  margin: 0;
-  font-size: 1rem;
-  color: #0f172a;
-  min-height: 1.5em;
-}
-
-.classroom-history {
+.portal-quiz-options {
   display: flex;
   flex-wrap: wrap;
-  gap: 0.5rem;
-  margin-top: 0.75rem;
-}
-
-.classroom-history .portal-chip,
-.classroom-history .portal-chip--muted {
-  cursor: default;
-}
-
-.classroom-timer-grid {
-  display: grid;
-  gap: 1rem;
-  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
   align-items: center;
+  gap: 0.7rem;
 }
 
-.classroom-timer-controls {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 1rem;
+.portal-quiz-chip {
+  display: inline-flex;
   align-items: center;
-  justify-content: space-between;
-}
-
-.classroom-timer-display {
-  min-width: 160px;
-}
-
-.classroom-timer-time {
-  font-size: 2.4rem;
-  font-weight: 700;
-  color: #0f172a;
-  margin: 0;
-}
-
-.classroom-timer-buttons {
-  display: flex;
-  gap: 0.5rem;
-}
-
-.classroom-timer-bar {
-  position: relative;
-  width: 100%;
-  height: 12px;
+  gap: 0.55rem;
+  width: fit-content;
+  padding: 0.38rem 0.45rem 0.38rem 0.8rem;
+  border: 1px solid rgba(148, 163, 184, 0.36);
   border-radius: 999px;
-  background: rgba(148, 163, 184, 0.25);
-  overflow: hidden;
-  margin-top: 0.5rem;
+  background: #ffffff;
+  color: #334155;
+  font-weight: 500;
+  box-shadow: 0 8px 24px -18px rgba(15, 23, 42, 0.35);
 }
 
-.classroom-timer-bar span {
-  position: absolute;
-  inset: 0 auto 0 0;
-  width: 100%;
-  background: #f6f8ff;
-  transform-origin: left center;
-  transform: scaleX(0);
-  transition: transform 0.2s ease;
+.portal-quiz-chip span {
+  white-space: nowrap;
 }
 
-.classroom-notes {
-  margin-top: 0.5rem;
+.portal-quiz-chip select.input {
+  min-width: 4rem;
+  width: auto;
+  margin: 0;
+  padding: 0.52rem 2rem 0.52rem 0.9rem;
+  border-radius: 12px;
+  border-color: rgba(148, 163, 184, 0.32);
+  background-color: #f8fafc;
+  color: #0f172a;
+  font-weight: 600;
+}
+
+.portal-quiz-chip select[name="time"] {
+  min-width: 7.7rem;
+}
+
+@media (max-width: 560px) {
+  .portal-quiz-options {
+    align-items: stretch;
+  }
+
+  .portal-quiz-chip {
+    width: 100%;
+    justify-content: space-between;
+  }
 }
 
 .portal-actions {

--- a/portal/supabase-portal.html
+++ b/portal/supabase-portal.html
@@ -105,91 +105,8 @@
     <div id="portalTabs" class="portal-tabs hidden" data-portal-tablist role="tablist" aria-label="Eines del professorat">
       <button id="tab-classes" class="portal-tab" type="button" data-tab="classes" role="tab" aria-controls="classesPanel" aria-selected="false">Classes</button>
       <button id="tab-assignments" class="portal-tab" type="button" data-tab="assignments" role="tab" aria-controls="assignmentsPanel" aria-selected="false">Assignacions</button>
-      <button id="tab-classroom" class="portal-tab" type="button" data-tab="classroom" role="tab" aria-controls="classroomPanel" aria-selected="false">Gestió d'aula</button>
       <button id="tab-results" class="portal-tab" type="button" data-tab="results" role="tab" aria-controls="resultsPanel" aria-selected="false">Resultats</button>
     </div>
-
-    <section id="classroomPanel" class="portal-tabpanel hidden" data-tab-panel="classroom" role="tabpanel" aria-labelledby="tab-classroom">
-      <section class="panel card">
-        <div class="portal-section-header">
-          <div>
-            <p class="portal-section-title">Participació equilibrada</p>
-            <h2>Selector aleatori d'alumnes</h2>
-            <p class="portal-muted">Recorre tota la llista sense repetir fins a reiniciar la ronda.</p>
-          </div>
-          <div class="portal-actions">
-            <button id="classroomResetPicks" class="btn-ghost" type="button">Reinicia ronda</button>
-          </div>
-        </div>
-
-        <div class="classroom-random-grid">
-          <label>
-            <span class="portal-field-label">Classe</span>
-            <select id="classroomClassSelect" class="input"></select>
-          </label>
-          <div class="classroom-random-actions">
-            <button id="classroomPickStudent" class="btn-primary" type="button">Tria un alumne</button>
-            <p id="classroomPickResult" class="classroom-pick-result portal-muted" role="status" aria-live="polite"></p>
-          </div>
-        </div>
-
-        <div id="classroomPickHistory" class="classroom-history"></div>
-      </section>
-
-      <section class="panel card">
-        <div class="portal-section-header">
-          <div>
-            <p class="portal-section-title">Control del temps</p>
-            <h2>Temporitzador de classe</h2>
-            <p class="portal-muted">Marca els minuts d'una activitat, pausa quan calgui i reinicia fàcilment.</p>
-          </div>
-          <div class="portal-actions">
-            <button id="classroomTimerReset" class="btn-ghost" type="button">Reinicia</button>
-          </div>
-        </div>
-
-        <div class="classroom-timer-grid">
-          <label>
-            <span class="portal-field-label">Minuts</span>
-            <input id="classroomTimerMinutes" class="input" type="number" min="1" max="120" value="5" />
-          </label>
-          <div class="classroom-timer-controls">
-            <div class="classroom-timer-display" aria-live="polite">
-              <p id="classroomTimerDisplay" class="classroom-timer-time">05:00</p>
-              <p id="classroomTimerStatus" class="portal-muted" style="margin:0">Preparat</p>
-            </div>
-            <div class="classroom-timer-buttons">
-              <button id="classroomTimerToggle" class="btn-primary" type="button">Inicia</button>
-            </div>
-          </div>
-        </div>
-
-        <div class="classroom-timer-bar" aria-hidden="true">
-          <span id="classroomTimerProgress"></span>
-        </div>
-      </section>
-
-      <section class="panel card">
-        <div class="portal-section-header">
-          <div>
-            <p class="portal-section-title">Seguiment ràpid</p>
-            <h2>Notes de classe</h2>
-            <p class="portal-muted">Anota incidències, encàrrecs o idees sense sortir del gestor.</p>
-          </div>
-          <div class="portal-actions">
-            <button id="classroomNotesSave" class="btn-secondary" type="button">Desa</button>
-          </div>
-        </div>
-
-        <div class="portal-form portal-form--stack">
-          <label>
-            <span class="portal-field-label">Notes ràpides</span>
-            <textarea id="classroomNotes" class="input" rows="5" placeholder="Puntua la participació, recordatoris, acord amb alumnat..."></textarea>
-            <span id="classroomNotesStatus" class="portal-muted" role="status" aria-live="polite"></span>
-          </label>
-        </div>
-      </section>
-    </section>
 
     <section id="classesPanel" class="portal-tabpanel hidden" data-tab-panel="classes" role="tabpanel" aria-labelledby="tab-classes">
       <section class="panel card">
@@ -273,27 +190,39 @@
               <p id="moduleConfigNotice" class="portal-muted hidden"></p>
             </div>
           </div>
-          <div class="portal-form portal-form--three">
-            <label>
-              <span class="portal-field-label">Preguntes</span>
-              <input class="input" name="count" type="number" min="1" max="200" value="20" />
+          <div class="portal-quiz-options" aria-label="Opcions comunes de la prova">
+            <label class="portal-quiz-chip">
+              <span>Preguntes</span>
+              <select class="input" name="count" aria-label="Nombre de preguntes">
+                <option selected>10</option>
+                <option>20</option>
+                <option>30</option>
+                <option>50</option>
+              </select>
             </label>
-            <label>
-              <span class="portal-field-label">Temps (minuts)</span>
-              <input class="input" name="time" type="number" min="0" max="180" value="0" />
+            <label class="portal-quiz-chip">
+              <span>Temps (min)</span>
+              <select class="input" name="time" aria-label="Temps màxim en minuts">
+                <option value="0" selected>Sense límit</option>
+                <option>5</option>
+                <option>10</option>
+                <option>15</option>
+                <option>20</option>
+              </select>
             </label>
-            <label id="assignmentLevelField">
-              <span class="portal-field-label">Nivell (1-4)</span>
-              <input id="assignmentLevelInput" class="input" name="level" type="number" min="1" max="4" value="1" />
+            <label id="assignmentLevelField" class="portal-quiz-chip">
+              <span>Nivell (1–4)</span>
+              <select id="assignmentLevelInput" class="input" name="level" aria-label="Nivell de dificultat">
+                <option selected>1</option>
+                <option>2</option>
+                <option>3</option>
+                <option>4</option>
+              </select>
             </label>
           </div>
           <label>
             <span class="portal-field-label">Data límit (opcional)</span>
             <input class="input" name="due_at" type="datetime-local" />
-          </label>
-          <label class="portal-form--stack">
-            <span class="portal-field-label">Notes internes</span>
-            <textarea class="input" name="notes" rows="3" placeholder="Anota criteris o instruccions per recordar-les"></textarea>
           </label>
           <div class="portal-actions">
             <button class="btn-primary" type="submit">Publica la prova</button>

--- a/portal/supabase-portal.js
+++ b/portal/supabase-portal.js
@@ -34,19 +34,6 @@ const state = {
   submissions: [],
   activeSubmissionId: null,
   focusedResultAssignmentId: null,
-  classroom: {
-    selectedClassId: '',
-    pools: new Map(),
-    lastPick: '',
-    timer: {
-      durationSeconds: 300,
-      remainingSeconds: 300,
-      running: false,
-      endsAt: null,
-      handle: null,
-    },
-    notes: '',
-  },
   assignmentDraft: {
     moduleId: '',
     options: {},
@@ -104,24 +91,9 @@ const elements = {
   refreshResults: document.getElementById('refreshResults'),
   resultsClassFilter: document.getElementById('resultsClassFilter'),
   resultsAssignmentFilter: document.getElementById('resultsAssignmentFilter'),
-  classroomClassSelect: document.getElementById('classroomClassSelect'),
-  classroomPickButton: document.getElementById('classroomPickStudent'),
-  classroomPickResult: document.getElementById('classroomPickResult'),
-  classroomPickHistory: document.getElementById('classroomPickHistory'),
-  classroomResetPicks: document.getElementById('classroomResetPicks'),
-  classroomTimerMinutes: document.getElementById('classroomTimerMinutes'),
-  classroomTimerToggle: document.getElementById('classroomTimerToggle'),
-  classroomTimerReset: document.getElementById('classroomTimerReset'),
-  classroomTimerDisplay: document.getElementById('classroomTimerDisplay'),
-  classroomTimerStatus: document.getElementById('classroomTimerStatus'),
-  classroomTimerProgress: document.getElementById('classroomTimerProgress'),
-  classroomNotes: document.getElementById('classroomNotes'),
-  classroomNotesStatus: document.getElementById('classroomNotesStatus'),
-  classroomNotesSave: document.getElementById('classroomNotesSave'),
 };
 
 let previewChannel = null;
-let notesSaveTimeout = null;
 
 
 function getNested(source, keys, fallback) {
@@ -450,7 +422,6 @@ function formatDateTime(value, options = { dateStyle: 'short', timeStyle: 'short
 function renderClassOptions() {
   const selects = [
     { node: elements.assignmentClassSelect, stateAccessor: null },
-    { node: elements.classroomClassSelect, stateAccessor: 'classroom.selectedClassId' },
   ];
 
   const options = state.classes.map((cls) => ({
@@ -523,264 +494,6 @@ function getClassById(classId) {
   return state.classes.find((cls) => cls.id === classId) || null;
 }
 
-function ensureClassroomSelection() {
-  if (!Array.isArray(state.classes) || state.classes.length === 0) {
-    state.classroom.selectedClassId = '';
-    return;
-  }
-  if (!state.classroom.selectedClassId) {
-    state.classroom.selectedClassId = state.classes[0].id;
-    return;
-  }
-  const exists = state.classes.some((cls) => cls.id === state.classroom.selectedClassId);
-  if (!exists) {
-    state.classroom.selectedClassId = state.classes[0].id;
-  }
-}
-
-function getClassroomPool(classId) {
-  const cls = getClassById(classId);
-  const roster = cls && Array.isArray(cls.students) ? cls.students : [];
-  const signature = roster.join('||');
-  const existing = state.classroom.pools.get(classId);
-  if (!existing || existing.signature !== signature) {
-    state.classroom.pools.set(classId, {
-      remaining: [...roster],
-      history: [],
-      signature,
-    });
-  }
-  return state.classroom.pools.get(classId);
-}
-
-function resetClassroomPool(classId) {
-  if (!classId) return;
-  const cls = getClassById(classId);
-  const roster = cls && Array.isArray(cls.students) ? cls.students : [];
-  state.classroom.pools.set(classId, {
-    remaining: [...roster],
-    history: [],
-    signature: roster.join('||'),
-  });
-  state.classroom.lastPick = '';
-}
-
-function pickRandomStudent() {
-  const classId = state.classroom.selectedClassId;
-  const pool = getClassroomPool(classId || '');
-  const roster = pool ? pool.remaining : [];
-  if (!classId || !pool || !Array.isArray(roster) || roster.length === 0) {
-    state.classroom.lastPick = classId ? 'Cap alumne pendent' : 'Afegeix alumnes a la classe';
-    renderClassroomRandom();
-    return;
-  }
-  const index = Math.floor(Math.random() * roster.length);
-  const [selected] = roster.splice(index, 1);
-  pool.history.unshift(selected);
-  state.classroom.lastPick = selected;
-  renderClassroomRandom();
-}
-
-function renderClassroomRandom() {
-  ensureClassroomSelection();
-  const select = elements.classroomClassSelect;
-  const pool = getClassroomPool(state.classroom.selectedClassId || '');
-  const remaining = pool && Array.isArray(pool.remaining) ? pool.remaining.length : 0;
-  const history = pool && Array.isArray(pool.history) ? pool.history : [];
-
-  if (select) {
-    select.value = state.classroom.selectedClassId || '';
-  }
-  if (elements.classroomPickResult) {
-    elements.classroomPickResult.textContent = state.classroom.lastPick || "Fes clic per triar un alumne a l'atzar";
-  }
-  if (elements.classroomPickHistory) {
-    elements.classroomPickHistory.innerHTML = '';
-    if (history.length === 0) {
-      const chip = document.createElement('span');
-      chip.className = 'portal-chip portal-chip--muted';
-      chip.textContent = 'Encara no hi ha torns assignats';
-      elements.classroomPickHistory.appendChild(chip);
-    } else {
-      history.slice(0, 12).forEach((name) => {
-        const chip = document.createElement('span');
-        chip.className = 'portal-chip';
-        chip.textContent = name;
-        elements.classroomPickHistory.appendChild(chip);
-      });
-    }
-    if (remaining > 0) {
-      const chip = document.createElement('span');
-      chip.className = 'portal-chip portal-chip--muted';
-      chip.textContent = `${remaining} pendent(s)`;
-      elements.classroomPickHistory.appendChild(chip);
-    }
-  }
-}
-
-function clamp(value, min, max) {
-  return Math.min(Math.max(value, min), max);
-}
-
-function formatSeconds(totalSeconds) {
-  if (!Number.isFinite(totalSeconds)) return '00:00';
-  const seconds = Math.max(0, Math.round(totalSeconds));
-  const mins = Math.floor(seconds / 60)
-    .toString()
-    .padStart(2, '0');
-  const secs = (seconds % 60).toString().padStart(2, '0');
-  return `${mins}:${secs}`;
-}
-
-function clearClassroomTimerHandle() {
-  if (state.classroom.timer.handle) {
-    clearInterval(state.classroom.timer.handle);
-    state.classroom.timer.handle = null;
-  }
-}
-
-function syncTimerDurationFromInput({ updateRemaining = false } = {}) {
-  const minutes = elements.classroomTimerMinutes
-    ? clamp(Number.parseInt(elements.classroomTimerMinutes.value, 10) || 0, 1, 120)
-    : 5;
-  const durationSeconds = minutes * 60;
-  state.classroom.timer.durationSeconds = durationSeconds;
-  if (updateRemaining || !state.classroom.timer.running) {
-    state.classroom.timer.remainingSeconds = durationSeconds;
-  }
-  renderClassroomTimer();
-}
-
-function renderClassroomTimer() {
-  const timer = state.classroom.timer;
-  if (elements.classroomTimerMinutes && !elements.classroomTimerMinutes.matches(':focus')) {
-    elements.classroomTimerMinutes.value = Math.max(1, Math.round((timer.durationSeconds || 60) / 60));
-  }
-  if (elements.classroomTimerDisplay) {
-    elements.classroomTimerDisplay.textContent = formatSeconds(timer.remainingSeconds);
-  }
-  if (elements.classroomTimerToggle) {
-    elements.classroomTimerToggle.textContent = timer.running ? 'Pausa' : timer.remainingSeconds <= 0 ? 'Reinicia' : 'Inicia';
-  }
-  if (elements.classroomTimerStatus) {
-    elements.classroomTimerStatus.textContent = timer.running
-      ? 'Compte enrere en marxa'
-      : timer.remainingSeconds <= 0
-        ? 'Temps completat'
-        : 'Preparat';
-  }
-  if (elements.classroomTimerProgress) {
-    const total = timer.durationSeconds || 1;
-    const ratio = clamp(timer.remainingSeconds / total, 0, 1);
-    elements.classroomTimerProgress.style.transform = `scaleX(${ratio})`;
-  }
-}
-
-function tickClassroomTimer() {
-  const timer = state.classroom.timer;
-  if (!timer.running || !timer.endsAt) return;
-  const remainingMs = Math.max(0, timer.endsAt - Date.now());
-  timer.remainingSeconds = Math.round(remainingMs / 1000);
-  if (timer.remainingSeconds <= 0) {
-    timer.running = false;
-    timer.endsAt = null;
-    clearClassroomTimerHandle();
-  }
-  renderClassroomTimer();
-}
-
-function startClassroomTimer() {
-  const timer = state.classroom.timer;
-  if (timer.running) return;
-  if (timer.remainingSeconds <= 0) {
-    timer.remainingSeconds = timer.durationSeconds || 60;
-  }
-  timer.running = true;
-  timer.endsAt = Date.now() + timer.remainingSeconds * 1000;
-  clearClassroomTimerHandle();
-  timer.handle = setInterval(tickClassroomTimer, 500);
-  renderClassroomTimer();
-}
-
-function pauseClassroomTimer() {
-  const timer = state.classroom.timer;
-  timer.running = false;
-  timer.endsAt = null;
-  clearClassroomTimerHandle();
-  renderClassroomTimer();
-}
-
-function resetClassroomTimer() {
-  const timer = state.classroom.timer;
-  timer.running = false;
-  timer.endsAt = null;
-  clearClassroomTimerHandle();
-  syncTimerDurationFromInput({ updateRemaining: true });
-}
-
-function loadClassroomNotes() {
-  const classId = state.classroom.selectedClassId;
-  const storageKey = classId ? `fq_classroom_notes_${classId}` : null;
-  if (!storageKey) {
-    state.classroom.notes = '';
-    return;
-  }
-  try {
-    state.classroom.notes = localStorage.getItem(storageKey) || '';
-  } catch (error) {
-    console.warn('No s\'han pogut llegir les notes locals', error);
-    state.classroom.notes = '';
-  }
-}
-
-function saveClassroomNotes() {
-  const classId = state.classroom.selectedClassId;
-  const storageKey = classId ? `fq_classroom_notes_${classId}` : null;
-  if (!storageKey) return;
-  try {
-    localStorage.setItem(storageKey, state.classroom.notes || '');
-    if (elements.classroomNotesStatus) {
-      elements.classroomNotesStatus.textContent = 'Notes desades localment';
-    }
-  } catch (error) {
-    console.warn('No s\'han pogut desar les notes locals', error);
-    if (elements.classroomNotesStatus) {
-      elements.classroomNotesStatus.textContent = 'No s\'ha pogut desar (consulta permisos del navegador)';
-    }
-  }
-}
-
-function renderClassroomNotes() {
-  if (elements.classroomNotes) {
-    elements.classroomNotes.value = state.classroom.notes || '';
-    elements.classroomNotes.disabled = !state.classroom.selectedClassId;
-  }
-  if (elements.classroomNotesStatus) {
-    elements.classroomNotesStatus.textContent = state.classroom.selectedClassId
-      ? 'Es desen al navegador per a aquesta classe'
-      : 'Crea una classe per activar les notes';
-  }
-}
-
-function handleClassroomNotesInput() {
-  if (!elements.classroomNotes) return;
-  state.classroom.notes = elements.classroomNotes.value;
-  if (notesSaveTimeout) {
-    clearTimeout(notesSaveTimeout);
-  }
-  notesSaveTimeout = setTimeout(() => {
-    saveClassroomNotes();
-    notesSaveTimeout = null;
-  }, 600);
-}
-
-function renderClassroomTools() {
-  ensureClassroomSelection();
-  loadClassroomNotes();
-  renderClassroomRandom();
-  renderClassroomTimer();
-  renderClassroomNotes();
-}
 
 
 function resolveModuleInfo(moduleOrId) {
@@ -1764,7 +1477,6 @@ function renderAll() {
   renderAssignments();
   buildResultsFilters();
   renderResults();
-  renderClassroomTools();
 }
 
 async function updateRoster(classId, rawValue, feedbackNode) {
@@ -1987,8 +1699,6 @@ async function createAssignment(formData) {
   const storedLevel = usesLevels ? level : 0;
   const levelLabel = usesLevels ? null : moduleFreeLevelLabel(module);
   const dueAtRaw = readFormValue(formData, 'due_at').trim();
-  const notesValue = readFormValue(formData, 'notes').trim();
-  const notes = notesValue ? notesValue : null;
   const moduleOptions = collectModuleOptions();
   const questionSet = Array.isArray(state.assignmentDraft.questionSet)
     ? state.assignmentDraft.questionSet.map((question) => {
@@ -2032,7 +1742,6 @@ async function createAssignment(formData) {
       quiz_config: quizConfig,
       status: 'published',
       due_at: dueAtRaw ? new Date(dueAtRaw).toISOString() : null,
-      notes,
     };
     const { error } = await client.from('assignments').insert(payload);
     if (error) throw error;
@@ -2380,49 +2089,6 @@ function setupEventListeners() {
   }
   if (elements.resultsAssignmentFilter) {
     elements.resultsAssignmentFilter.addEventListener('change', renderResults);
-  }
-  if (elements.classroomClassSelect) {
-    elements.classroomClassSelect.addEventListener('change', () => {
-      state.classroom.selectedClassId = elements.classroomClassSelect.value || '';
-      resetClassroomPool(state.classroom.selectedClassId);
-      loadClassroomNotes();
-      renderClassroomTools();
-    });
-  }
-  if (elements.classroomPickButton) {
-    elements.classroomPickButton.addEventListener('click', pickRandomStudent);
-  }
-  if (elements.classroomResetPicks) {
-    elements.classroomResetPicks.addEventListener('click', () => {
-      resetClassroomPool(state.classroom.selectedClassId);
-      renderClassroomRandom();
-    });
-  }
-  if (elements.classroomTimerMinutes) {
-    const handler = () => syncTimerDurationFromInput({ updateRemaining: !state.classroom.timer.running });
-    elements.classroomTimerMinutes.addEventListener('input', handler);
-    elements.classroomTimerMinutes.addEventListener('change', handler);
-  }
-  if (elements.classroomTimerToggle) {
-    elements.classroomTimerToggle.addEventListener('click', () => {
-      if (state.classroom.timer.running) {
-        pauseClassroomTimer();
-      } else {
-        startClassroomTimer();
-      }
-    });
-  }
-  if (elements.classroomTimerReset) {
-    elements.classroomTimerReset.addEventListener('click', resetClassroomTimer);
-  }
-  if (elements.classroomNotes) {
-    elements.classroomNotes.addEventListener('input', handleClassroomNotesInput);
-  }
-  if (elements.classroomNotesSave) {
-    elements.classroomNotesSave.addEventListener('click', () => {
-      state.classroom.notes = elements.classroomNotes ? elements.classroomNotes.value : state.classroom.notes;
-      saveClassroomNotes();
-    });
   }
   window.addEventListener('message', handlePreviewMessage);
   window.addEventListener('storage', handlePreviewStorageMessage);

--- a/style.css
+++ b/style.css
@@ -1284,6 +1284,29 @@ a.btn-secondary{
 .timer{font-variant-numeric: tabular-nums; font-feature-settings:"tnum" on; font-size:1.2rem}
 .chip{border:1px solid var(--hair); color:var(--muted); padding:6px 10px; border-radius:999px; background:#fff}
 
+.mini-table{
+  width:100%;
+  border-collapse:separate;
+  border-spacing:0;
+  overflow:hidden;
+  border:1px solid var(--hair);
+  border-radius:14px;
+  background:#fff;
+  box-shadow:0 10px 24px rgba(15,23,42,.06);
+}
+.mini-table th,
+.mini-table td{
+  padding:10px 12px;
+  text-align:center;
+  border-bottom:1px solid var(--hair);
+  border-right:1px solid var(--hair);
+}
+.mini-table th:last-child,
+.mini-table td:last-child{border-right:0}
+.mini-table tr:last-child td{border-bottom:0}
+.mini-table th{background:#eef4ff;color:#1f2937;font-weight:800}
+.mini-table td{font-weight:700;color:#0f172a}
+
 .quiz.sci-mode {
   grid-template-columns: 1fr;
 }


### PR DESCRIPTION
### Motivation
- Introduce a new math module for contextual "Problemes competencials" and expose configurable subthemes in the portal. 
- Simplify the teacher portal by removing the classroom utility panel (random picker, timer, notes) and streamline assignment/quiz options UI.

### Description
- Added a new math module `competencial` with generator `genCompetencial`, subtheme list and problem bank in `math.js`, and registered it in the `MATH_MODULES` array. 
- Added module option definitions for `competencial` (defaults, normalize, render, collect, summarize) and new subtheme list in `portal/module-config.js`, and wired it into `MODULE_OPTION_DEFINITIONS`. 
- Added the module entry to the site module catalog in `portal/modules-data.js`. 
- Updated assignment creation UI in `portal/supabase-portal.html` to use compact quiz option chips and selects for `count`, `time` and `level`, and removed the internal `notes` field from the form. 
- Removed the classroom tab and its feature set (random student selector, timer, and classroom notes) from `portal/supabase-portal.html` and stripped out related state, DOM elements, rendering functions and event handlers from `portal/supabase-portal.js`. 
- Updated admin/portal styles: replaced classroom-specific CSS with `.portal-quiz-options` / `.portal-quiz-chip` styles in `portal/portal.css`, and added a `.mini-table` style to `style.css` used by some competencial problems. 
- Minor content edits in `app.html` to adjust the home hero copy and remove the standalone challenges entry.
- Integrated `competencial` into the module configuration UI in `main.js` so `openConfig`/`collectConfigValues` handle the new module.

### Testing
- Ran the repository's automated checks: `npm run lint` and the existing test suite (`npm test`) on the modified codebase; both completed without errors.
- Executed a quick smoke test of the portal UI (build/start) to verify assignment form rendering and module configuration panel for `competencial` loaded correctly.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a444e8ab8e0832db926bae2f715a667)