### PR TITLE
Millora la configuració de Reptes: partida ràpida, eliminació de 'Torneig classe' i ajust de disseny

### DIFF
--- a/app.html
+++ b/app.html
@@ -30,7 +30,7 @@
     .challenges-hero { border:1px solid #d8e0f4; border-radius:18px; background:#f8faff; padding:1rem; margin-bottom:1rem; }
     .challenges-hero h2 { margin:0; color:#1f4ea1; }
     .challenges-hero p { margin:.25rem 0 .85rem; }
-    .challenges-cards { display:grid; grid-template-columns: repeat(3, minmax(0,1fr)); gap:.7rem; }
+    .challenges-cards { display:grid; grid-template-columns: repeat(2, minmax(0,1fr)); gap:.7rem; }
     .challenge-card { border:1px solid #ccd8f2; border-radius:14px; background:#fff; padding:.85rem; display:grid; gap:.25rem; }
     .challenge-card .icon { font-size:1.4rem; }
     .challenge-card h3 { margin:0; font-size:1rem; }
@@ -67,6 +67,9 @@
     .ttm-module-field select { border: 1px solid #cbd7f6; border-radius: 10px; padding: .55rem .65rem; background: #fff; }
     .ttm-actions { margin-top: .9rem; display: flex; justify-content: space-between; gap: .5rem; }
     .ttm-error { min-height: 1.2rem; color: #b42318; margin-top: .4rem; }
+    .ttm-quick-start { margin-top:.75rem; padding:.7rem .95rem; border:1px solid #b9c9f2; border-radius:12px; background:#eef4ff; display:flex; align-items:center; justify-content:space-between; gap:.75rem; }
+    .ttm-quick-start p { margin:0; color:#344054; font-size:.9rem; }
+    .ttm-quick-start button { flex:0 0 auto; }
 
     .ttm-titlebar { text-align: center; color: #1f73b8; font-weight: 900; letter-spacing: .04em; font-size: clamp(1.2rem, 2.4vw, 2rem); margin-bottom: .9rem; }
     .ttm-quick-actions { display:flex; justify-content:flex-end; margin-bottom:.45rem; }
@@ -159,6 +162,7 @@
       .ttm-grid4 { grid-template-columns: repeat(2, minmax(0,1fr)); }
       .ttm-grid3 { grid-template-columns: 1fr; }
       .ttm-team-inputs, .ttm-layout { grid-template-columns: 1fr; }
+      .ttm-quick-start { align-items:stretch; flex-direction:column; }
       .ttm-hud { grid-template-columns: 1fr; }
       .cap-status { grid-template-columns: 1fr; }
       .ttm-timer { justify-self: start; }
@@ -393,11 +397,6 @@
               <h3>Joc de les xapes</h3>
               <p>Resposta correcta = tir de xapa fins al primer gol.</p>
             </article>
-            <article class="challenge-card is-soon">
-              <span class="icon">🏆</span>
-              <h3>Torneig classe</h3>
-              <p>Noves modalitats en preparació. Properament.</p>
-            </article>
           </div>
         </section>
 <section id="challengesSection" class="panel card challenge-section" aria-labelledby="challengesTitle">
@@ -407,7 +406,11 @@
               <div class="ttm-card">
                 <p class="ttm-step-label" id="ttmStepLabel">Pas 1 de 3</p>
                 <h3 id="ttmSetupTitle" class="ttm-title">Configuració del joc de la corda</h3>
-                <p class="subtitle">Quan entris al joc, primer et demanarà de quin mòdul vols fer el repte.</p>
+                <p class="subtitle">Personalitza la partida en tres passos o comença directament amb la configuració recomanada.</p>
+                <div class="ttm-quick-start">
+                  <p><strong>Partida ràpida:</strong> aritmètica, nivell fàcil i dos equips.</p>
+                  <button class="btn-secondary" type="button" id="ttmQuickStart">Comença ara</button>
+                </div>
 
                 <div class="ttm-step is-active" data-step="1">
                   <label class="ttm-module-field">
@@ -547,7 +550,11 @@ Nil"></textarea>
               <div class="ttm-card">
                 <p class="ttm-step-label" id="capStepLabel">Pas 1 de 3</p>
                 <h3 id="capSetupTitle" class="ttm-title">Configuració del joc de les xapes</h3>
-                <p class="subtitle">Resposta correcta = 1 tir de xapa. La partida acaba al primer gol.</p>
+                <p class="subtitle">Personalitza la partida en tres passos o comença directament amb la configuració recomanada.</p>
+                <div class="ttm-quick-start">
+                  <p><strong>Partida ràpida:</strong> aritmètica, nivell fàcil i primer gol.</p>
+                  <button class="btn-secondary" type="button" id="capQuickStart">Comença ara</button>
+                </div>
                 <div class="ttm-step is-active" data-step="1">
                   <label class="ttm-module-field">Mòdul del repte
                     <select id="capModuleSelect"><option value="arith">Aritmètica</option></select>
@@ -935,6 +942,7 @@ Nil"></textarea></label>
 
       const els = {
         modal: document.getElementById('ttmModal'),
+        quickStart: document.getElementById('ttmQuickStart'),
         stepLabel: document.getElementById('ttmStepLabel'),
         steps: Array.from(root.querySelectorAll('.ttm-step')),
         prevStep: document.getElementById('ttmPrevStep'),
@@ -1411,6 +1419,16 @@ Nil"></textarea></label>
         els.levelButtons.forEach(b => b.classList.toggle('is-selected', b === btn));
       }));
 
+      els.quickStart?.addEventListener('click', () => {
+        state.moduleId = 'arith';
+        state.difficulty = 'easy';
+        state.gameMode = 'duel';
+        if (els.moduleSelect) els.moduleSelect.value = 'arith';
+        els.levelButtons.forEach((btn) => btn.classList.toggle('is-selected', btn.dataset.level === 'easy'));
+        state.step = 3;
+        els.nextStep.click();
+      });
+
       els.prevStep.addEventListener('click', () => {
         state.step = Math.max(1, state.step - 1);
         els.setupError.textContent = '';
@@ -1568,6 +1586,7 @@ Nil"></textarea></label>
 
       const els = {
         modal: document.getElementById('capModal'),
+        quickStart: document.getElementById('capQuickStart'),
         stepLabel: document.getElementById('capStepLabel'),
         steps: Array.from(root.querySelectorAll('.ttm-step')),
         prevStep: document.getElementById('capPrevStep'),
@@ -2117,6 +2136,15 @@ Nil"></textarea></label>
       els.modeButtons.forEach((btn) => btn.addEventListener('click', () => { state.gameMode = btn.dataset.mode === 'champ' ? 'champ' : 'duel'; applyGameModeUi(); }));
       els.bracketSize?.addEventListener('change', () => { state.bracketSize = Number(els.bracketSize.value || 4) === 8 ? 8 : 4; });
       els.levelButtons.forEach((btn) => btn.addEventListener('click', () => { state.difficulty = btn.dataset.level; els.levelButtons.forEach((b) => b.classList.toggle('is-selected', b === btn)); }));
+      els.quickStart?.addEventListener('click', () => {
+        state.moduleId = 'arith';
+        state.difficulty = 'easy';
+        state.gameMode = 'duel';
+        if (els.moduleSelect) els.moduleSelect.value = 'arith';
+        els.levelButtons.forEach((btn) => btn.classList.toggle('is-selected', btn.dataset.level === 'easy'));
+        state.step = 3;
+        els.nextStep.click();
+      });
       els.prevStep.addEventListener('click', () => { state.step = Math.max(1, state.step - 1); els.setupError.textContent = ''; updateStepUi(); });
       els.nextStep.addEventListener('click', () => {
         els.setupError.textContent = '';


### PR DESCRIPTION
### Motivation

- Fer la configuració de les partides més ràpida i intuïtiva afegint una opció de "partida ràpida" per als jocs més usats. 
- Reduir l'espai innecessari a la portada de Reptes eliminant la targeta informativa de "Torneig classe" que omplia espai sense funcionalitat activa. 
- Millorar l'encaix visual en pantalles petites i equilibrar la graella de targetes perquè els dos jocs ocupin l'espai de forma simètrica.

### Description

- He actualitzat `app.html` per canviar la graella de cartes de reptes de 3 a 2 columnes modificant la regla CSS `.challenges-cards` i ajustant la resposta a mòbil. 
- He eliminat la targeta informativa `Torneig classe` de la portada de Reptes per deixar només les dues modalitats actives. 
- He afegit un bloc UI `ttm-quick-start`/`capQuickStart` amb estil i botons per iniciar una ``Partida ràpida`` tant al modal del "Joc de la corda" com al del "Joc de les xapes". 
- He implementat els handlers JS que apliquen la configuració recomanada (`moduleId: 'arith'`, `difficulty: 'easy'`, `gameMode: 'duel'`) i disparen el flux d'inici de partida (mitjançant `els.nextStep.click()`), i he fet petits ajustos CSS responsius per a aquest bloc.

### Testing

- S'ha executat `git diff --check` i no va retornar errors. 
- S'han extret i comprovat la sintaxi dels 6 scripts inline amb `node --check` i tots han passat la comprovació de sintaxi. 
- S'ha fet un commit amb els canvis i `git status --short --branch` mostra la branca neta després del commit.
- No s'han pogut executar proves de navegadors automàtiques perquè l'entorn no disposa d'un binari de navegador i l'eina `make_pr` no està disponible, per tant l'obertura automàtica de la PR no es va realitzar aquí.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a79d6c7b734832db891312f8387cf45)