### PR TITLE
Unify FocusMind game setup UI, add shared stylesheet and Quick Start for Challenges

### DIFF
--- a/app.html
+++ b/app.html
@@ -30,7 +30,7 @@
     .challenges-hero { border:1px solid #d8e0f4; border-radius:18px; background:#f8faff; padding:1rem; margin-bottom:1rem; }
     .challenges-hero h2 { margin:0; color:#1f4ea1; }
     .challenges-hero p { margin:.25rem 0 .85rem; }
-    .challenges-cards { display:grid; grid-template-columns: repeat(3, minmax(0,1fr)); gap:.7rem; }
+    .challenges-cards { display:grid; grid-template-columns: repeat(2, minmax(0,1fr)); gap:.7rem; }
     .challenge-card { border:1px solid #ccd8f2; border-radius:14px; background:#fff; padding:.85rem; display:grid; gap:.25rem; }
     .challenge-card .icon { font-size:1.4rem; }
     .challenge-card h3 { margin:0; font-size:1rem; }
@@ -67,6 +67,9 @@
     .ttm-module-field select { border: 1px solid #cbd7f6; border-radius: 10px; padding: .55rem .65rem; background: #fff; }
     .ttm-actions { margin-top: .9rem; display: flex; justify-content: space-between; gap: .5rem; }
     .ttm-error { min-height: 1.2rem; color: #b42318; margin-top: .4rem; }
+    .ttm-quick-start { margin-top:.75rem; padding:.7rem .95rem; border:1px solid #b9c9f2; border-radius:12px; background:#eef4ff; display:flex; align-items:center; justify-content:space-between; gap:.75rem; }
+    .ttm-quick-start p { margin:0; color:#344054; font-size:.9rem; }
+    .ttm-quick-start button { flex:0 0 auto; }
 
     .ttm-titlebar { text-align: center; color: #1f73b8; font-weight: 900; letter-spacing: .04em; font-size: clamp(1.2rem, 2.4vw, 2rem); margin-bottom: .9rem; }
     .ttm-quick-actions { display:flex; justify-content:flex-end; margin-bottom:.45rem; }
@@ -159,6 +162,7 @@
       .ttm-grid4 { grid-template-columns: repeat(2, minmax(0,1fr)); }
       .ttm-grid3 { grid-template-columns: 1fr; }
       .ttm-team-inputs, .ttm-layout { grid-template-columns: 1fr; }
+      .ttm-quick-start { align-items:stretch; flex-direction:column; }
       .ttm-hud { grid-template-columns: 1fr; }
       .cap-status { grid-template-columns: 1fr; }
       .ttm-timer { justify-self: start; }
@@ -375,7 +379,7 @@
             <p class="subtitle">Tria un joc i configura la partida per mòdul.</p>
           </div>
           <div class="controls">
-            <button class="btn-secondary" type="button" onclick="showView('home')">← Torna</button>
+            <button class="btn-secondary" type="button" onclick="leaveChallenges()">← Torna</button>
           </div>
         </div>
 
@@ -393,11 +397,6 @@
               <h3>Joc de les xapes</h3>
               <p>Resposta correcta = tir de xapa fins al primer gol.</p>
             </article>
-            <article class="challenge-card is-soon">
-              <span class="icon">🏆</span>
-              <h3>Torneig classe</h3>
-              <p>Noves modalitats en preparació. Properament.</p>
-            </article>
           </div>
         </section>
 <section id="challengesSection" class="panel card challenge-section" aria-labelledby="challengesTitle">
@@ -407,7 +406,11 @@
               <div class="ttm-card">
                 <p class="ttm-step-label" id="ttmStepLabel">Pas 1 de 3</p>
                 <h3 id="ttmSetupTitle" class="ttm-title">Configuració del joc de la corda</h3>
-                <p class="subtitle">Quan entris al joc, primer et demanarà de quin mòdul vols fer el repte.</p>
+                <p class="subtitle">Personalitza la partida en tres passos o comença directament amb la configuració recomanada.</p>
+                <div class="ttm-quick-start">
+                  <p><strong>Partida ràpida:</strong> aritmètica, nivell fàcil i dos equips.</p>
+                  <button class="btn-secondary" type="button" id="ttmQuickStart">Comença ara</button>
+                </div>
 
                 <div class="ttm-step is-active" data-step="1">
                   <label class="ttm-module-field">
@@ -547,7 +550,11 @@ Nil"></textarea>
               <div class="ttm-card">
                 <p class="ttm-step-label" id="capStepLabel">Pas 1 de 3</p>
                 <h3 id="capSetupTitle" class="ttm-title">Configuració del joc de les xapes</h3>
-                <p class="subtitle">Resposta correcta = 1 tir de xapa. La partida acaba al primer gol.</p>
+                <p class="subtitle">Personalitza la partida en tres passos o comença directament amb la configuració recomanada.</p>
+                <div class="ttm-quick-start">
+                  <p><strong>Partida ràpida:</strong> aritmètica, nivell fàcil i primer gol.</p>
+                  <button class="btn-secondary" type="button" id="capQuickStart">Comença ara</button>
+                </div>
                 <div class="ttm-step is-active" data-step="1">
                   <label class="ttm-module-field">Mòdul del repte
                     <select id="capModuleSelect"><option value="arith">Aritmètica</option></select>
@@ -935,6 +942,7 @@ Nil"></textarea></label>
 
       const els = {
         modal: document.getElementById('ttmModal'),
+        quickStart: document.getElementById('ttmQuickStart'),
         stepLabel: document.getElementById('ttmStepLabel'),
         steps: Array.from(root.querySelectorAll('.ttm-step')),
         prevStep: document.getElementById('ttmPrevStep'),
@@ -1411,6 +1419,16 @@ Nil"></textarea></label>
         els.levelButtons.forEach(b => b.classList.toggle('is-selected', b === btn));
       }));
 
+      els.quickStart?.addEventListener('click', () => {
+        state.moduleId = 'arith';
+        state.difficulty = 'easy';
+        state.gameMode = 'duel';
+        if (els.moduleSelect) els.moduleSelect.value = 'arith';
+        els.levelButtons.forEach((btn) => btn.classList.toggle('is-selected', btn.dataset.level === 'easy'));
+        state.step = 3;
+        els.nextStep.click();
+      });
+
       els.prevStep.addEventListener('click', () => {
         state.step = Math.max(1, state.step - 1);
         els.setupError.textContent = '';
@@ -1486,7 +1504,7 @@ Nil"></textarea></label>
         updateStepUi();
         updateHud();
         updateRope();
-        if (typeof showView === 'function') showView('home');
+        if (typeof leaveChallenges === 'function') leaveChallenges();
       });
 
       populateModuleOptions();
@@ -1568,6 +1586,7 @@ Nil"></textarea></label>
 
       const els = {
         modal: document.getElementById('capModal'),
+        quickStart: document.getElementById('capQuickStart'),
         stepLabel: document.getElementById('capStepLabel'),
         steps: Array.from(root.querySelectorAll('.ttm-step')),
         prevStep: document.getElementById('capPrevStep'),
@@ -2117,6 +2136,15 @@ Nil"></textarea></label>
       els.modeButtons.forEach((btn) => btn.addEventListener('click', () => { state.gameMode = btn.dataset.mode === 'champ' ? 'champ' : 'duel'; applyGameModeUi(); }));
       els.bracketSize?.addEventListener('change', () => { state.bracketSize = Number(els.bracketSize.value || 4) === 8 ? 8 : 4; });
       els.levelButtons.forEach((btn) => btn.addEventListener('click', () => { state.difficulty = btn.dataset.level; els.levelButtons.forEach((b) => b.classList.toggle('is-selected', b === btn)); }));
+      els.quickStart?.addEventListener('click', () => {
+        state.moduleId = 'arith';
+        state.difficulty = 'easy';
+        state.gameMode = 'duel';
+        if (els.moduleSelect) els.moduleSelect.value = 'arith';
+        els.levelButtons.forEach((btn) => btn.classList.toggle('is-selected', btn.dataset.level === 'easy'));
+        state.step = 3;
+        els.nextStep.click();
+      });
       els.prevStep.addEventListener('click', () => { state.step = Math.max(1, state.step - 1); els.setupError.textContent = ''; updateStepUi(); });
       els.nextStep.addEventListener('click', () => {
         els.setupError.textContent = '';
@@ -2146,7 +2174,7 @@ Nil"></textarea></label>
       els.exitBtn?.addEventListener('click', () => {
         state.running = false; clearInterval(state.timerId); clearTimeout(state.replay.timeoutId); state.step = 1; state.timeLeft = DURATION; state.tournament = null;
         els.result.hidden = true; els.modal.hidden = false; if (els.replay) els.replay.hidden = true; hideAimPreview(); updateStepUi(); updateHud(); renderShotState(); resetField();
-        if (typeof showView === 'function') showView('home');
+        if (typeof leaveChallenges === 'function') leaveChallenges();
       });
 
       setupChipDrag('blue', els.chipBlue);

--- a/focusmind-games/bar/bar.html
+++ b/focusmind-games/bar/bar.html
@@ -5,20 +5,21 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>La Barra · FocusMind</title>
   <link rel="stylesheet" href="bar.css" />
+  <link rel="stylesheet" href="../shared-setup.css" />
 </head>
 <body>
   <main class="cafe-shell">
-    <section class="cafe-hero" id="introPanel">
-      <div>
-        <p class="cafe-kicker">FocusMind · Atenció, memòria i velocitat</p>
+    <section class="cafe-hero fm-unified-setup" id="introPanel">
+      <div class="fm-setup-copy">
+        <p class="cafe-kicker fm-setup-kicker">FocusMind · Atenció, memòria i velocitat</p>
         <h1>La Barra 🍎</h1>
-        <p>Memoritza la comanda de cada client a la barra i prepara-la ràpidament. Cada ronda afegeix més elements i menys temps.</p>
-        <div class="cafe-actions">
-          <button class="cafe-btn" id="startBtn">Començar partida</button>
-          <a class="cafe-btn cafe-btn--ghost" href="/focusmind" id="backLink">Tornar a FocusMind</a>
+        <p class="fm-setup-lead">Memoritza la comanda de cada client a la barra i prepara-la ràpidament. Cada ronda afegeix més elements i menys temps.</p>
+        <div class="cafe-actions fm-setup-actions">
+          <button class="cafe-btn fm-setup-primary" id="startBtn">Començar partida</button>
+          <a class="cafe-btn cafe-btn--ghost fm-setup-secondary" href="/focusmind" id="backLink">Tornar a FocusMind</a>
         </div>
       </div>
-      <div class="cafe-counter" aria-hidden="true">
+      <div class="cafe-counter fm-setup-visual" aria-hidden="true">
         <span>🍎</span><span>🥐</span><span>🧃</span><span>🍰</span>
       </div>
     </section>

--- a/focusmind-games/bar2/bar2.html
+++ b/focusmind-games/bar2/bar2.html
@@ -5,6 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>La Cafeteria · FocusMind</title>
     <link rel="stylesheet" href="bar2.css" />
+    <link rel="stylesheet" href="../shared-setup.css" />
   </head>
   <body>
     <main id="focusquiz-root">
@@ -21,12 +22,12 @@
           </div>
         </header>
 
-        <section class="setup-panel" id="setup-panel" aria-label="Configuracio de partida">
-          <div>
-            <h2>Nova partida</h2>
-            <p>Serveix 8 clients. La velocitat ajuda, pero el joc valora sobretot mirar, recordar i preparar be.</p>
-          </div>
-          <div class="setup-grid">
+        <section class="setup-panel fm-unified-setup" id="setup-panel" aria-label="Configuració de partida">
+          <div class="fm-setup-copy">
+            <p class="fm-setup-kicker">FocusMind · Atenció, memòria i precisió</p>
+            <h1>La Cafeteria ☕</h1>
+            <p class="fm-setup-lead">Serveix 8 clients. La velocitat ajuda, però el joc valora sobretot mirar, recordar i preparar bé.</p>
+          <div class="setup-grid fm-setup-options">
             <fieldset>
               <legend>Mode</legend>
               <label><input type="radio" name="mode" value="practice" checked /> Practica</label>
@@ -41,7 +42,12 @@
               <label><input type="radio" name="level" value="4" /> 4</label>
             </fieldset>
           </div>
-          <button class="primary-button" id="start-game" type="button">Comen&ccedil;ar</button>
+          <div class="fm-setup-actions">
+            <button class="primary-button fm-setup-primary" id="start-game" type="button">Començar partida</button>
+            <a class="ghost-button fm-setup-secondary" href="/focusmind">Tornar a FocusMind</a>
+          </div>
+          </div>
+          <div class="fm-setup-visual" aria-hidden="true"><span>☕</span><span>🥛</span><span>🫘</span><span>🧊</span></div>
         </section>
 
         <section class="game-layout is-hidden" id="game-panel" aria-label="Partida de Cafe Focus">

--- a/focusmind-games/memoria-monstres/memoria-monstres.html
+++ b/focusmind-games/memoria-monstres/memoria-monstres.html
@@ -4,20 +4,27 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Memòria de Monstres</title>
-  <link rel="stylesheet" href="memoria-de-monstres.css">
+  <link rel="stylesheet" href="memoria-monstres.css">
+  <link rel="stylesheet" href="../shared-setup.css">
 </head>
 <body>
   <main class="game-shell">
-    <section id="start-screen" class="panel start-panel">
-      <p class="eyebrow">Joc independent · Memòria de treball</p>
+    <section id="start-screen" class="panel start-panel fm-unified-setup">
+      <div class="fm-setup-copy">
+      <p class="eyebrow fm-setup-kicker">FocusMind · Memòria visual</p>
       <h1>Memòria de Monstres</h1>
-      <p class="intro">Observa monstres amb característiques diferents i respon després quina criatura havia aparegut. Practica memòria de treball, discriminació visual i concentració.</p>
-      <div class="level-selector" aria-label="Selector de nivell">
+      <p class="intro fm-setup-lead">Observa monstres amb característiques diferents i respon després quina criatura havia aparegut. Practica memòria de treball, discriminació visual i concentració.</p>
+      <div class="level-selector fm-setup-options" aria-label="Selector de nivell">
         <button class="level-option selected" type="button" data-level="1" aria-pressed="true"><strong>Nivell 1</strong><span>2 monstres · preguntes simples</span></button>
         <button class="level-option" type="button" data-level="2" aria-pressed="false"><strong>Nivell 2</strong><span>3 monstres · més detalls</span></button>
         <button class="level-option" type="button" data-level="3" aria-pressed="false"><strong>Nivell 3</strong><span>4 monstres · combinacions complexes</span></button>
       </div>
-      <button id="start-button" class="primary-button" type="button">Començar</button>
+      <div class="fm-setup-actions">
+        <button id="start-button" class="primary-button fm-setup-primary" type="button">Començar partida</button>
+        <a class="fm-setup-secondary" href="/focusmind">Tornar a FocusMind</a>
+      </div>
+      </div>
+      <div class="fm-setup-visual" aria-hidden="true"><span>👾</span><span>👹</span><span>👻</span><span>🤓</span></div>
     </section>
 
     <section id="play-screen" class="panel hidden" aria-live="polite">
@@ -50,6 +57,6 @@
       <div class="actions"><button id="restart-button" class="primary-button" type="button">Tornar a jugar</button></div>
     </section>
   </main>
-  <script src="memoria-de-monstres.js"></script>
+  <script src="memoria-monstres.js"></script>
 </body>
 </html>

--- a/focusmind-games/robot-programador/robot-programador.html
+++ b/focusmind-games/robot-programador/robot-programador.html
@@ -5,19 +5,26 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Robot Programador</title>
   <link rel="stylesheet" href="robot-programador.css">
+  <link rel="stylesheet" href="../shared-setup.css">
 </head>
 <body>
   <main class="game-shell">
-    <section id="start-screen" class="panel start-panel">
-      <p class="eyebrow">Joc independent · Funcions executives</p>
+    <section id="start-screen" class="panel start-panel fm-unified-setup">
+      <div class="fm-setup-copy">
+      <p class="eyebrow fm-setup-kicker">FocusMind · Planificació i lògica</p>
       <h1>Robot Programador</h1>
-      <p class="intro">Programa el robot perquè arribi a la meta amb instruccions simples. Practica planificació, lògica, anticipació d'errors i control executiu.</p>
-      <div class="level-selector" aria-label="Selector de nivell">
+      <p class="intro fm-setup-lead">Programa el robot perquè arribi a la meta amb instruccions simples. Practica planificació, lògica, anticipació d'errors i control executiu.</p>
+      <div class="level-selector fm-setup-options" aria-label="Selector de nivell">
         <button class="level-option selected" type="button" data-level="1" aria-pressed="true"><strong>Nivell 1</strong><span>Tauler 5x5 · camins clars</span></button>
         <button class="level-option" type="button" data-level="2" aria-pressed="false"><strong>Nivell 2</strong><span>Tauler 6x6 · salts i obstacles</span></button>
         <button class="level-option" type="button" data-level="3" aria-pressed="false"><strong>Nivell 3</strong><span>Tauler 7x7 · repeticions útils</span></button>
       </div>
-      <button id="start-button" class="primary-button" type="button">Començar</button>
+      <div class="fm-setup-actions">
+        <button id="start-button" class="primary-button fm-setup-primary" type="button">Començar partida</button>
+        <a class="fm-setup-secondary" href="/focusmind">Tornar a FocusMind</a>
+      </div>
+      </div>
+      <div class="fm-setup-visual" aria-hidden="true"><span>🤖</span><span>➡️</span><span>🧱</span><span>🏁</span></div>
     </section>
 
     <section id="play-screen" class="panel hidden" aria-live="polite">

--- a/focusmind-games/sequencia-lluminosa/sequencia-lluminosa.html
+++ b/focusmind-games/sequencia-lluminosa/sequencia-lluminosa.html
@@ -7,20 +7,24 @@
   <link rel="stylesheet" href="/style.css" />
   <link rel="stylesheet" href="/focusmind.css" />
   <link rel="stylesheet" href="./sequencia-lluminosa.css" />
+  <link rel="stylesheet" href="../shared-setup.css" />
 </head>
 <body class="focusmind-game-page">
   <main id="sequenciaLluminosaApp" class="sequencia-lluminosa" aria-labelledby="sequenciaLluminosaTitle">
-    <section class="sequencia-lluminosa__card">
-      <p class="sequencia-lluminosa__kicker">FocusMind · Memòria</p>
+    <section class="sequencia-lluminosa__card fm-unified-setup">
+      <div class="fm-setup-copy">
+      <p class="sequencia-lluminosa__kicker fm-setup-kicker">FocusMind · Memòria</p>
       <h1 id="sequenciaLluminosaTitle">Seqüència lluminosa</h1>
-      <p class="sequencia-lluminosa__lead">
-        Plantilla preparada perquè hi puguis bolcar el codi del joc. Manté els botons bàsics, el retorn a FocusMind i el guardat de resultats.
+      <p class="sequencia-lluminosa__lead fm-setup-lead">
+        Observa l'ordre en què s'il·luminen les caselles i reprodueix la seqüència. Cada encert posa una mica més a prova la teva memòria.
       </p>
-      <div class="sequencia-lluminosa__actions">
-        <button id="sequenciaStart" class="fm-btn" type="button">Comença</button>
-        <a class="fm-btn secondary" href="/focusmind">Torna a FocusMind</a>
+      <div class="sequencia-lluminosa__actions fm-setup-actions">
+        <button id="sequenciaStart" class="fm-btn fm-setup-primary" type="button">Començar partida</button>
+        <a class="fm-btn secondary fm-setup-secondary" href="/focusmind">Tornar a FocusMind</a>
       </div>
       <p id="sequenciaStatus" class="sequencia-lluminosa__status" role="status" aria-live="polite">A punt per començar.</p>
+      </div>
+      <div class="fm-setup-visual" aria-hidden="true"><span>🟦</span><span>🟨</span><span>🟩</span><span>🟪</span></div>
     </section>
 
     <section class="sequencia-lluminosa__stage" aria-label="Zona de joc">

--- a/focusmind-games/shared-setup.css
+++ b/focusmind-games/shared-setup.css
@@ -1,0 +1,178 @@
+:root {
+  --fm-setup-ink: #24150d;
+  --fm-setup-muted: #735745;
+  --fm-setup-coffee: #8b4b27;
+  --fm-setup-caramel: #d9984a;
+  --fm-setup-mint: #87d9b8;
+  --fm-setup-line: rgba(139, 75, 39, 0.18);
+  --fm-setup-card: rgba(255, 252, 246, 0.9);
+}
+
+body:has(.fm-unified-setup) {
+  background:
+    radial-gradient(circle at 16% 12%, rgba(217, 152, 74, 0.34), transparent 32%),
+    radial-gradient(circle at 85% 4%, rgba(135, 217, 184, 0.34), transparent 28%),
+    linear-gradient(135deg, #fffaf0 0%, #f2dfc8 54%, #e8f7ef 100%);
+}
+
+body:has(.fm-unified-setup) :is(.cafe-shell, .game-shell, .sequencia-lluminosa) {
+  width: min(1180px, calc(100% - 28px));
+  margin-inline: auto;
+}
+
+#focusquiz-root:has(#setup-panel:not(.is-hidden)) {
+  width: min(1180px, calc(100% - 28px));
+  height: auto;
+  min-height: 100svh;
+  padding: 28px 0;
+  overflow: visible;
+}
+
+.cafe-app:has(#setup-panel:not(.is-hidden)) > .cafe-topbar { display: none; }
+
+.fm-unified-setup {
+  width: 100%;
+  min-height: min(720px, calc(100svh - 56px));
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(280px, .78fr);
+  gap: clamp(24px, 4vw, 52px);
+  align-items: center;
+  padding: clamp(28px, 5vw, 58px) !important;
+  border: 1px solid var(--fm-setup-line) !important;
+  border-radius: 32px !important;
+  color: var(--fm-setup-ink) !important;
+  background: var(--fm-setup-card) !important;
+  box-shadow: 0 24px 70px rgba(91, 48, 22, 0.18) !important;
+  backdrop-filter: blur(16px);
+  overflow: hidden;
+}
+
+.fm-unified-setup::before,
+.fm-unified-setup::after { display: none !important; }
+
+.fm-setup-copy { min-width: 0; }
+
+.fm-setup-kicker {
+  margin: 0 0 1.35rem !important;
+  color: var(--fm-setup-coffee) !important;
+  font-size: .86rem !important;
+  font-weight: 900 !important;
+  letter-spacing: .08em !important;
+  text-transform: uppercase;
+}
+
+.fm-unified-setup h1 {
+  margin: 0 0 1.25rem !important;
+  color: var(--fm-setup-ink) !important;
+  font-size: clamp(3rem, 8vw, 6.8rem) !important;
+  line-height: .92 !important;
+  letter-spacing: -.055em !important;
+}
+
+.fm-setup-lead {
+  max-width: 58ch !important;
+  margin: 0 !important;
+  color: var(--fm-setup-muted) !important;
+  font-size: clamp(1.02rem, 1.8vw, 1.25rem) !important;
+  line-height: 1.55 !important;
+}
+
+.fm-setup-options {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: .75rem;
+  margin-top: 1.35rem;
+}
+
+.level-selector.fm-setup-options { grid-template-columns: repeat(3, minmax(0, 1fr)); }
+
+.fm-setup-options > fieldset,
+.fm-setup-options > .level-option {
+  margin: 0;
+  border: 1px solid var(--fm-setup-line) !important;
+  border-radius: 18px !important;
+  background: rgba(255, 255, 255, .72) !important;
+  box-shadow: none !important;
+}
+
+.fm-setup-options > fieldset { padding: 1rem; }
+.fm-setup-options > fieldset legend { color: var(--fm-setup-coffee); font-weight: 900; }
+
+.fm-setup-options > .level-option {
+  min-height: 92px;
+  padding: 1rem;
+  color: var(--fm-setup-ink);
+  text-align: left;
+}
+
+.fm-setup-options > .level-option.selected,
+.fm-setup-options > .level-option:has(input:checked) {
+  border-color: var(--fm-setup-caramel) !important;
+  outline: 3px solid rgba(217, 152, 74, .2) !important;
+  background: #fff8ee !important;
+}
+
+.fm-setup-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: .8rem;
+  margin-top: 1.45rem;
+}
+
+.fm-setup-primary,
+.fm-setup-secondary {
+  min-height: 54px !important;
+  padding: 0 1.3rem !important;
+  display: inline-grid !important;
+  place-items: center;
+  border-radius: 18px !important;
+  font: inherit;
+  font-weight: 900 !important;
+  text-decoration: none;
+  cursor: pointer;
+}
+
+.fm-setup-primary {
+  border: 0 !important;
+  color: #fff !important;
+  background: linear-gradient(135deg, var(--fm-setup-coffee), var(--fm-setup-caramel)) !important;
+  box-shadow: 0 14px 28px rgba(139, 75, 39, .22) !important;
+}
+
+.fm-setup-secondary {
+  border: 1px solid var(--fm-setup-line) !important;
+  color: var(--fm-setup-coffee) !important;
+  background: rgba(255, 255, 255, .72) !important;
+  box-shadow: none !important;
+}
+
+.fm-setup-visual {
+  min-height: 360px;
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 1rem;
+  padding: 1.2rem;
+  border-radius: 30px;
+  background: linear-gradient(160deg, rgba(139, 75, 39, .14), rgba(255, 255, 255, .46));
+}
+
+.fm-setup-visual span {
+  display: grid;
+  place-items: center;
+  min-height: 130px;
+  border-radius: 26px;
+  background: rgba(255, 255, 255, .72);
+  font-size: clamp(3rem, 7vw, 5rem);
+  filter: drop-shadow(0 10px 12px rgba(91, 48, 22, .1));
+}
+
+@media (max-width: 800px) {
+  .fm-unified-setup { grid-template-columns: 1fr; min-height: auto; }
+  .level-selector.fm-setup-options { grid-template-columns: 1fr; }
+  .fm-setup-visual { min-height: 240px; }
+}
+
+@media (max-width: 560px) {
+  .fm-setup-options { grid-template-columns: 1fr; }
+  .fm-setup-actions > * { width: 100%; }
+}

--- a/main.js
+++ b/main.js
@@ -546,6 +546,15 @@ function showView(name){
   if(name==='focusmind' && typeof window.initFocusMind === 'function' && !$('#view-focusmind')?.dataset.ready) window.initFocusMind();
 }
 
+function leaveChallenges(){
+  const params = new URLSearchParams(window.location.search);
+  if (params.get('embedded') === '1') {
+    window.location.assign('app.html');
+    return;
+  }
+  showView('home');
+}
+
 
 function showFocusMind(){
   if (window.location.pathname !== '/focusmind') {


### PR DESCRIPTION
### Motivation
- Provide a consistent, modernized setup experience across FocusMind mini-games by unifying per-game setup panels into a single visual pattern. 
- Add a quick-start flow to let teachers/students launch common challenge configurations quickly. 
- Improve navigation when exiting challenge modals, including correct behavior for embedded views.

### Description
- Add a new `focusmind-games/shared-setup.css` file and introduce a unified setup layout via classes such as `fm-unified-setup`, `fm-setup-copy`, `fm-setup-actions`, and `fm-setup-visual` that are applied across several game HTML files. 
- Update multiple game pages (`bar/bar.html`, `bar2/bar2.html`, `memoria-monstres/memoria-monstres.html`, `robot-programador/robot-programador.html`, `sequencia-lluminosa/sequencia-lluminosa.html`) to adopt the unified setup markup and to reference the shared stylesheet. 
- Enhance the Challenges UI in `app.html` by adding quick-start UI blocks to the tug (`ttm`) and caps (`cap`) setup modals, wiring `ttmQuickStart`/`capQuickStart` buttons to set recommended options and advance the setup, and adding minor copy/layout tweaks (including changing the challenges cards grid from 3 to 2 columns). 
- Add `leaveChallenges()` to `main.js` to handle returning from the challenges view and updated challenge exit/back buttons and modal exit handlers to call `leaveChallenges()` (with special handling when `embedded=1`). 
- Update module resource references and a couple of filename references in HTML to match renamed scripts/styles (e.g. `memoria-monstres.css` / `memoria-monstres.js`).

### Testing
- No automated tests were added or run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a79d6c7b734832db891312f8387cf45)