### PR TITLE
Add teacher dashboard UI, redesign portal pages and styles for FocusQuiz

### DIFF
--- a/portal/portal.css
+++ b/portal/portal.css
@@ -2690,3 +2690,452 @@
     flex: 1 1 auto;
   }
 }
+
+/* Exact dashboard layout based on the approved teacher-portal reference. */
+body.teacher-portal {
+  --dashboard-navy: #20213f;
+  --dashboard-purple: #6251e8;
+  --dashboard-ink: #101b38;
+  --dashboard-muted: #63718e;
+  --dashboard-border: #d9e0ed;
+  margin: 0;
+  min-height: 100vh;
+  color: var(--dashboard-ink);
+  background: #f4f6fb;
+}
+
+body.teacher-portal > .topbar {
+  position: fixed;
+  z-index: 50;
+  inset: 0 auto 0 0;
+  width: 300px;
+  height: 100vh;
+  padding: 33px 25px;
+  overflow-y: auto;
+  color: #fff;
+  background: var(--dashboard-navy);
+  border: 0;
+  box-shadow: none;
+}
+
+body.teacher-portal > .topbar .header-bar {
+  display: flex;
+  flex-direction: column;
+  align-items: stretch;
+  gap: 40px;
+  width: 100%;
+  height: auto;
+  margin: 0;
+  padding: 0;
+}
+
+body.teacher-portal > .topbar .brand {
+  display: flex;
+  align-items: center;
+  gap: 15px;
+  padding: 0;
+}
+
+body.teacher-portal > .topbar .brand .logo {
+  display: grid;
+  place-items: center;
+  width: 47px;
+  height: 47px;
+  border: 0;
+  border-radius: 14px;
+  color: #fff;
+  background: linear-gradient(145deg, #7667fa, #5949df);
+  box-shadow: none;
+  font-size: 1.15rem;
+  font-weight: 900;
+}
+
+body.teacher-portal > .topbar .brand h1 {
+  margin: 0;
+  color: #fff;
+  font-size: 1.2rem;
+  font-weight: 850;
+  letter-spacing: -0.025em;
+}
+
+body.teacher-portal > .topbar .main-nav,
+body.teacher-portal > .topbar .portal-tabs {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr);
+  align-items: stretch;
+  gap: 11px;
+  width: 100%;
+  padding: 0;
+  border: 0;
+  background: transparent;
+  box-shadow: none;
+  backdrop-filter: none;
+}
+
+body.teacher-portal > .topbar .main-nav { margin-top: 1px; }
+body.teacher-portal > .topbar .portal-tabs { margin-top: -29px; }
+
+body.teacher-portal > .topbar .main-nav .pill,
+body.teacher-portal > .topbar .portal-tab {
+  position: relative;
+  z-index: 1;
+  display: flex;
+  align-items: center;
+  justify-content: flex-start;
+  gap: 18px;
+  width: 100%;
+  min-width: 0;
+  min-height: 57px;
+  padding: 0 14px;
+  border: 0;
+  border-radius: 14px;
+  color: #bdc3e2;
+  background: transparent;
+  box-shadow: none;
+  font-size: 1rem;
+  font-weight: 750;
+  text-align: left;
+  text-transform: none;
+  letter-spacing: normal;
+  overflow: visible;
+  transform: none;
+  box-sizing: border-box;
+}
+
+body.teacher-portal > .topbar .portal-tabs::before,
+body.teacher-portal > .topbar .portal-tab::after { content: none; display: none; }
+
+body.teacher-portal > .topbar .main-nav .pill span,
+body.teacher-portal > .topbar .portal-tab span {
+  display: inline-grid;
+  place-items: center;
+  width: 18px;
+  color: #c7caff;
+  font-size: 1.1rem;
+}
+
+body.teacher-portal > .topbar .main-nav .pill:hover,
+body.teacher-portal > .topbar .portal-tab:hover,
+body.teacher-portal > .topbar .portal-tab--active {
+  color: #fff;
+  background: rgba(255, 255, 255, 0.11);
+}
+
+body.teacher-portal > .topbar .portal-home-link { color: #fff; background: rgba(255, 255, 255, 0.11); }
+body.teacher-portal > .topbar .portal-tab--active { color: #bdc3e2; background: transparent; }
+body.teacher-portal > .topbar .portal-tab--active:hover { color: #fff; background: rgba(255, 255, 255, 0.11); }
+body.teacher-portal > .topbar .portal-tab[aria-selected='true'] {
+  border: 0;
+  color: #bdc3e2;
+  background: transparent;
+  box-shadow: none;
+}
+body.teacher-portal.dashboard-subpage > .topbar .portal-home-link { color: #bdc3e2; background: transparent; }
+body.teacher-portal.dashboard-subpage > .topbar .portal-tab[aria-selected='true'] {
+  color: #fff;
+  background: rgba(255, 255, 255, 0.11);
+}
+
+body.teacher-portal .portal-main {
+  display: grid;
+  gap: 25px;
+  width: auto;
+  max-width: none;
+  min-height: 100vh;
+  margin: 0 0 0 300px;
+  padding: 30px clamp(34px, 3.7vw, 70px) 70px;
+  background: #f4f6fb;
+}
+
+body.teacher-portal .teacher-dashboard { display: grid; gap: 0; }
+body.teacher-portal .teacher-dashboard.hidden { display: none !important; }
+body.teacher-portal.dashboard-subpage .dashboard-welcome,
+body.teacher-portal.dashboard-subpage .dashboard-stats { display: none; }
+body.teacher-portal.dashboard-subpage .teacher-dashboard { margin-bottom: 25px; }
+
+body.teacher-portal .dashboard-topbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 30px;
+}
+
+body.teacher-portal .dashboard-search { width: min(525px, 44vw); }
+body.teacher-portal .dashboard-search input {
+  width: 100%;
+  height: 56px;
+  padding: 0 20px;
+  border: 1px solid var(--dashboard-border);
+  border-radius: 15px;
+  color: var(--dashboard-ink);
+  background: #fff;
+  outline: none;
+  font: inherit;
+  font-size: 1rem;
+}
+body.teacher-portal .dashboard-search input:focus { border-color: var(--dashboard-purple); box-shadow: 0 0 0 3px rgba(98, 81, 232, 0.12); }
+
+body.teacher-portal .dashboard-profile {
+  position: relative;
+  display: flex;
+  align-items: center;
+  gap: 13px;
+  padding: 0;
+  border: 0;
+  background: transparent;
+  box-shadow: none;
+}
+body.teacher-portal .dashboard-profile.hidden { display: none !important; }
+body.teacher-portal .dashboard-avatar {
+  display: grid;
+  place-items: center;
+  width: 51px;
+  height: 51px;
+  border-radius: 50%;
+  color: #4d42ad;
+  background: #dfdbff;
+  font-weight: 850;
+}
+body.teacher-portal .dashboard-profile-copy { display: grid; min-width: 100px; line-height: 1.3; }
+body.teacher-portal .dashboard-profile-copy strong { font-size: 1.05rem; }
+body.teacher-portal .dashboard-profile-copy span { color: var(--dashboard-muted); font-size: 0.86rem; }
+body.teacher-portal .dashboard-logout {
+  position: absolute;
+  top: 100%;
+  right: 0;
+  display: none;
+  width: max-content;
+  margin-top: 6px;
+  padding: 9px 12px;
+  border: 1px solid var(--dashboard-border);
+  border-radius: 10px;
+  color: var(--dashboard-ink);
+  background: #fff;
+}
+body.teacher-portal .dashboard-profile:hover .dashboard-logout,
+body.teacher-portal .dashboard-logout:focus { display: block; }
+
+body.teacher-portal .dashboard-welcome {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 25px;
+  margin-top: 55px;
+}
+body.teacher-portal .dashboard-welcome h1 {
+  margin: 0 0 8px;
+  color: var(--dashboard-ink);
+  font-size: clamp(2rem, 3vw, 2.55rem);
+  font-weight: 850;
+  letter-spacing: -0.045em;
+}
+body.teacher-portal .dashboard-welcome p { margin: 0; color: var(--dashboard-muted); font-size: 1rem; }
+body.teacher-portal .dashboard-welcome .btn-primary {
+  min-height: 54px;
+  padding: 0 22px;
+  border: 0;
+  border-radius: 13px;
+  color: #fff;
+  background: var(--dashboard-purple);
+  box-shadow: 0 14px 25px rgba(98, 81, 232, 0.2);
+  font-weight: 800;
+}
+
+body.teacher-portal .dashboard-stats {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 20px;
+  margin-top: 49px;
+}
+body.teacher-portal .dashboard-stat {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  min-height: 187px;
+  padding: 29px 26px;
+  border: 1px solid var(--dashboard-border);
+  border-radius: 24px;
+  background: #fff;
+  box-shadow: 0 18px 34px rgba(33, 44, 77, 0.07);
+}
+body.teacher-portal .dashboard-stat > div { display: flex; flex-direction: column; min-height: 128px; }
+body.teacher-portal .dashboard-stat span { color: var(--dashboard-muted); font-weight: 750; }
+body.teacher-portal .dashboard-stat strong { margin-top: auto; font-size: 2rem; line-height: 1; }
+body.teacher-portal .dashboard-stat small { margin-top: 11px; color: #0cb66e; font-size: 0.8rem; font-weight: 750; }
+body.teacher-portal .dashboard-stat:nth-child(2) small,
+body.teacher-portal .dashboard-stat:nth-child(4) small { color: var(--dashboard-muted); font-weight: 500; }
+body.teacher-portal .dashboard-stat i {
+  display: grid;
+  place-items: center;
+  width: 45px;
+  height: 45px;
+  border-radius: 13px;
+  color: #56647d;
+  background: #eeebff;
+  font-style: normal;
+}
+
+body.teacher-portal .portal-hero { margin-top: 25px; }
+body.teacher-portal .portal-main .panel.card {
+  border: 1px solid var(--dashboard-border);
+  border-radius: 24px;
+  background: #fff;
+  box-shadow: 0 18px 34px rgba(33, 44, 77, 0.07);
+}
+body.teacher-portal .portal-main .panel.card::before,
+body.teacher-portal .portal-main .panel.card::after { content: none; }
+body.teacher-portal .portal-main .panel.card:hover { transform: none; box-shadow: 0 18px 34px rgba(33, 44, 77, 0.07); }
+
+body.teacher-portal .portal-tabpanel {
+  display: grid;
+  gap: 25px;
+  margin: 0;
+  padding: 0;
+  border: 0;
+  border-radius: 0;
+  background: transparent;
+  box-shadow: none;
+  isolation: auto;
+}
+body.teacher-portal #classesPanel,
+body.teacher-portal #assignmentsPanel,
+body.teacher-portal #resultsPanel {
+  border: 0;
+  background: transparent;
+  box-shadow: none;
+}
+body.teacher-portal .portal-tabpanel.hidden { display: none !important; }
+body.teacher-portal #classesPanel { grid-template-columns: minmax(0, 1.9fr) minmax(320px, 0.85fr); align-items: start; }
+body.teacher-portal #classesPanel > .panel:nth-child(2) { grid-column: 1; grid-row: 1; min-height: 400px; padding: 31px; }
+body.teacher-portal #classesPanel > .panel:nth-child(1) { grid-column: 2; grid-row: 1; padding: 31px; }
+body.teacher-portal #classesPanel > .panel:nth-child(1) .portal-section-title { display: none; }
+body.teacher-portal #classesPanel > .panel:nth-child(1) h2 { font-size: 1.25rem; }
+body.teacher-portal #classesPanel > .panel:nth-child(2) .portal-section-header { align-items: flex-start; }
+body.teacher-portal #classesPanel > .panel:nth-child(2) .portal-section-header h2 { margin: 0 0 5px; font-size: 1.25rem; }
+
+body.teacher-portal .portal-grid { grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 16px; }
+body.teacher-portal .portal-class-card,
+body.teacher-portal .portal-assignment-card {
+  padding: 20px 22px;
+  border: 1px solid var(--dashboard-border);
+  border-radius: 17px;
+  background: #fff;
+  box-shadow: none;
+}
+body.teacher-portal .portal-class-card::before,
+body.teacher-portal .portal-assignment-card::before { content: none; }
+body.teacher-portal .portal-class-card:hover { border-color: #aaa1f6; box-shadow: 0 10px 25px rgba(50, 48, 100, 0.08); }
+body.teacher-portal .portal-class-card .portal-chip { display: none; }
+body.teacher-portal .portal-class-card > header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 16px;
+}
+body.teacher-portal .portal-class-name { margin: 0; font-size: 1.04rem; }
+body.teacher-portal .dashboard-class-code {
+  display: grid;
+  flex: 0 0 auto;
+  gap: 2px;
+  min-width: 82px;
+  margin: 0;
+  padding: 8px 11px;
+  border: 1px solid #d9d4ff;
+  border-radius: 11px;
+  color: #4d42ad;
+  background: #f0edff;
+  text-align: center;
+}
+body.teacher-portal .dashboard-class-code span {
+  font-size: 0.63rem;
+  font-weight: 750;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+body.teacher-portal .dashboard-class-code strong {
+  font-size: 0.88rem;
+  letter-spacing: 0.08em;
+}
+body.teacher-portal .portal-class-meta { color: var(--dashboard-muted); }
+body.teacher-portal .portal-class-meta dt { display: none; }
+body.teacher-portal .portal-class-meta dd { margin: 0; }
+body.teacher-portal .portal-class-meta dd:not(:nth-of-type(2)) { display: none; }
+body.teacher-portal .portal-class-meta dd:nth-of-type(2)::after { content: ' alumnes'; }
+body.teacher-portal .dashboard-class-progress { display: grid; gap: 10px; margin-top: 16px; }
+body.teacher-portal .dashboard-progress-track { height: 8px; overflow: hidden; border-radius: 999px; background: #e9edf5; }
+body.teacher-portal .dashboard-progress-track i { display: block; width: 0; height: 100%; border-radius: inherit; background: var(--dashboard-purple); }
+body.teacher-portal .dashboard-progress-copy { display: flex; justify-content: space-between; color: var(--dashboard-muted); font-size: 0.76rem; }
+body.teacher-portal .dashboard-progress-copy strong { color: var(--dashboard-muted); }
+body.teacher-portal .portal-class-actions { display: none; gap: 7px; margin-top: 14px; }
+body.teacher-portal .portal-class-card:focus-within .portal-class-actions,
+body.teacher-portal .portal-class-card:hover .portal-class-actions { display: flex; }
+body.teacher-portal .dashboard-filtered { display: none !important; }
+
+body.teacher-portal .dashboard-more { width: 67px; height: 55px; padding: 0; font-size: 1.2rem; }
+body.teacher-portal .dashboard-activity-list { display: grid; gap: 20px; margin-top: 24px; }
+body.teacher-portal .dashboard-activity-list > div { display: grid; grid-template-columns: 49px 1fr; align-items: start; gap: 14px; }
+body.teacher-portal .dashboard-activity-list i {
+  display: grid;
+  place-items: center;
+  width: 49px;
+  height: 49px;
+  border-radius: 14px;
+  color: var(--dashboard-ink);
+  background: #eaf8f2;
+  font-style: normal;
+  font-size: 1.15rem;
+}
+body.teacher-portal .dashboard-activity-list p { display: grid; gap: 4px; margin: 2px 0 0; font-size: 0.9rem; line-height: 1.35; }
+body.teacher-portal .dashboard-activity-list p span { color: var(--dashboard-muted); font-size: 0.8rem; }
+body.teacher-portal .dashboard-create-class { margin-top: 25px; border-radius: 14px; background: #f2efff; }
+body.teacher-portal .dashboard-create-class summary { padding: 14px 16px; color: #4d42ad; font-weight: 800; cursor: pointer; list-style: none; }
+body.teacher-portal .dashboard-create-class summary::-webkit-details-marker { display: none; }
+body.teacher-portal .dashboard-create-class .portal-form { padding: 0 16px 16px; }
+
+body.teacher-portal .portal-main .btn-primary { background: var(--dashboard-purple); border-color: var(--dashboard-purple); }
+body.teacher-portal .portal-main .input,
+body.teacher-portal .portal-main select,
+body.teacher-portal .portal-main textarea { border-color: var(--dashboard-border); border-radius: 12px; background: #fff; }
+
+@media (max-width: 1120px) {
+  body.teacher-portal > .topbar { width: 230px; }
+  body.teacher-portal .portal-main { margin-left: 230px; padding-inline: 30px; }
+  body.teacher-portal .dashboard-stats { grid-template-columns: repeat(2, 1fr); }
+  body.teacher-portal #classesPanel { grid-template-columns: 1fr; }
+  body.teacher-portal #classesPanel > .panel:nth-child(1),
+  body.teacher-portal #classesPanel > .panel:nth-child(2) { grid-column: 1; grid-row: auto; }
+}
+
+@media (max-width: 720px) {
+  body.teacher-portal { padding-bottom: 82px; }
+  body.teacher-portal > .topbar {
+    position: fixed;
+    inset: auto 12px 12px;
+    width: auto;
+    height: 66px;
+    padding: 8px 10px;
+    overflow: visible;
+    border: 1px solid var(--dashboard-border);
+    border-radius: 18px;
+    background: rgba(32, 33, 63, 0.97);
+  }
+  body.teacher-portal > .topbar .header-bar { flex-direction: row; align-items: center; gap: 8px; }
+  body.teacher-portal > .topbar .brand h1,
+  body.teacher-portal > .topbar .main-nav { display: none; }
+  body.teacher-portal > .topbar .brand .logo { width: 45px; height: 45px; }
+  body.teacher-portal > .topbar .portal-tabs { display: flex; justify-content: space-around; margin: 0; }
+  body.teacher-portal > .topbar .portal-tab { justify-content: center; width: 46px; min-height: 46px; padding: 0; font-size: 0; }
+  body.teacher-portal > .topbar .portal-tab span { font-size: 1rem; }
+  body.teacher-portal .portal-main { margin-left: 0; padding: 20px 16px 95px; }
+  body.teacher-portal .dashboard-search { width: 100%; }
+  body.teacher-portal .dashboard-profile-copy { display: none; }
+  body.teacher-portal .dashboard-avatar { width: 46px; height: 46px; }
+  body.teacher-portal .dashboard-welcome { align-items: flex-start; margin-top: 35px; }
+  body.teacher-portal .dashboard-welcome h1 { font-size: 2rem; }
+  body.teacher-portal .dashboard-welcome .btn-primary { white-space: nowrap; }
+  body.teacher-portal .dashboard-stats,
+  body.teacher-portal .portal-grid { grid-template-columns: 1fr; }
+  body.teacher-portal .dashboard-stat { min-height: 150px; }
+  body.teacher-portal #classesPanel > .panel:nth-child(1),
+  body.teacher-portal #classesPanel > .panel:nth-child(2) { padding: 22px; }
+}

--- a/portal/supabase-portal.html
+++ b/portal/supabase-portal.html
@@ -3,29 +3,68 @@
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <title>Focus Academy · Gestor de proves</title>
+  <meta name="description" content="Gestiona les classes, les proves i els resultats de FocusQuiz des del portal docent." />
+  <title>FocusQuiz · Portal docent</title>
   <link rel="stylesheet" href="../style.css" />
   <link rel="stylesheet" href="./portal.css" />
 </head>
-<body>
+<body class="teacher-portal">
   <header class="topbar">
     <div class="wrap row header-bar">
       <div class="brand">
         <div class="logo">FQ</div>
-        <h1>Focus Academy</h1>
+        <h1>FocusQuiz</h1>
       </div>
       <nav class="main-nav" aria-label="Navegació principal">
-        <a class="pill" href="../app.html">🏠 Inici</a>
-        <a class="pill" href="./supabase-portal.html" aria-current="page">Accés professorat</a>
+        <a class="pill portal-home-link" href="./supabase-portal.html" aria-current="page"><span aria-hidden="true">⌂</span> Inici</a>
       </nav>
+      <div id="portalTabs" class="portal-tabs hidden" data-portal-tablist role="tablist" aria-label="Eines del professorat">
+        <button id="tab-classes" class="portal-tab" type="button" data-tab="classes" role="tab" aria-controls="classesPanel" aria-selected="false"><span aria-hidden="true">▦</span> Classes</button>
+        <button id="tab-assignments" class="portal-tab" type="button" data-tab="assignments" role="tab" aria-controls="assignmentsPanel" aria-selected="false"><span aria-hidden="true">✓</span> Proves</button>
+        <button id="tab-results" class="portal-tab" type="button" data-tab="results" role="tab" aria-controls="resultsPanel" aria-selected="false"><span aria-hidden="true">↗</span> Resultats</button>
+        <a class="portal-tab portal-resource-link" href="../recursos.html"><span aria-hidden="true">◇</span> Recursos</a>
+      </div>
     </div>
   </header>
 
   <main class="wrap portal-main">
-    <section class="panel card portal-hero">
+    <div id="teacherDashboard" class="teacher-dashboard hidden">
+      <header class="dashboard-topbar">
+        <label class="dashboard-search">
+          <span class="portal-visually-hidden">Cerca classes, alumnes o proves</span>
+          <input id="dashboardSearch" type="search" placeholder="Cerca classes, alumnes o proves…" />
+        </label>
+        <section id="sessionPanel" class="dashboard-profile hidden">
+          <span id="sessionAvatar" class="dashboard-avatar" aria-hidden="true">D</span>
+          <span class="dashboard-profile-copy">
+            <strong id="sessionName"></strong>
+            <span id="sessionEmail">Professora</span>
+          </span>
+          <button id="logoutBtn" class="dashboard-logout" type="button">Tanca la sessió</button>
+          <span id="sessionWarning" class="portal-error hidden" role="status" aria-live="polite"></span>
+        </section>
+      </header>
+
+      <div class="dashboard-welcome">
+        <div>
+          <h1>Bon dia, <span id="dashboardFirstName">docent</span>! <span aria-hidden="true">👋</span></h1>
+          <p>Aquí tens un resum de l'activitat de les teves classes.</p>
+        </div>
+        <button id="dashboardNewTest" class="btn-primary" type="button">＋ Nova prova</button>
+      </div>
+
+      <section class="dashboard-stats" aria-label="Resum del curs">
+        <article class="dashboard-stat"><div><span>Alumnes</span><strong id="dashboardStudentCount">0</strong><small id="dashboardStudentNote">Alumnes registrats</small></div><i aria-hidden="true">♟</i></article>
+        <article class="dashboard-stat"><div><span>Classes actives</span><strong id="dashboardClassCount">0</strong><small>Curs 2025–26</small></div><i aria-hidden="true">▦</i></article>
+        <article class="dashboard-stat"><div><span>Proves creades</span><strong id="dashboardTestCount">0</strong><small id="dashboardPendingCount">0 pendents</small></div><i aria-hidden="true">✓</i></article>
+        <article class="dashboard-stat"><div><span>Mitjana global</span><strong id="dashboardAverage">—</strong><small>Resultats enviats</small></div><i aria-hidden="true">↗</i></article>
+      </section>
+    </div>
+
+    <section id="portalHero" class="panel card portal-hero">
       <div class="portal-hero-body">
-        <p class="portal-hero-kicker">Portal docent</p>
-        <h1>Gestiona classes, proves i notes</h1>
+        <p class="portal-hero-kicker">Espai del professorat</p>
+        <h1>Gestiona classes, proves i resultats</h1>
         <p class="subtitle">
           Crea una classe amb els alumnes, assigna qualsevol mòdul FocusQuiz i comparteix el codi perquè l'alumnat faci la prova sense
           registrar-se.
@@ -46,7 +85,7 @@
       </div>
     </section>
 
-    <div class="portal-auth-grid">
+    <div id="portalAuthGrid" class="portal-auth-grid">
       <section id="authPanel" class="panel card">
         <h2 style="margin-bottom:0.75rem">Inicia sessió com a docent</h2>
         <form id="loginForm" class="portal-form" autocomplete="on">
@@ -90,54 +129,40 @@
       </section>
     </div>
 
-    <section id="sessionPanel" class="panel card hidden">
-      <div class="portal-section-header">
-        <div>
-          <p class="portal-section-title" style="margin-bottom:0">Sessió docent</p>
-          <h2 style="margin:0" id="sessionName"></h2>
-          <p id="sessionEmail" class="portal-muted" style="margin-top:0.25rem"></p>
-        </div>
-        <button id="logoutBtn" class="btn-secondary" type="button">Tanca la sessió</button>
-      </div>
-      <div id="sessionWarning" class="portal-error hidden" role="status" aria-live="polite" style="margin-top:0.75rem"></div>
-    </section>
-
-    <div id="portalTabs" class="portal-tabs hidden" data-portal-tablist role="tablist" aria-label="Eines del professorat">
-      <button id="tab-classes" class="portal-tab" type="button" data-tab="classes" role="tab" aria-controls="classesPanel" aria-selected="false">Classes</button>
-      <button id="tab-assignments" class="portal-tab" type="button" data-tab="assignments" role="tab" aria-controls="assignmentsPanel" aria-selected="false">Assignacions</button>
-      <button id="tab-results" class="portal-tab" type="button" data-tab="results" role="tab" aria-controls="resultsPanel" aria-selected="false">Resultats</button>
-    </div>
-
     <section id="classesPanel" class="portal-tabpanel hidden" data-tab-panel="classes" role="tabpanel" aria-labelledby="tab-classes">
       <section class="panel card">
         <div class="portal-section-header">
-          <div>
-            <p class="portal-section-title">Nova classe</p>
-            <h2>Crea una classe i afegeix l'alumnat</h2>
-          </div>
-          <button id="refreshClasses" class="btn-ghost" type="button">Actualitza</button>
+          <h2>Activitat recent</h2>
+          <button id="refreshClasses" class="btn-ghost dashboard-more" type="button" aria-label="Actualitza l'activitat">•••</button>
         </div>
-        <form id="classCreateForm" class="portal-form portal-form--two">
-          <label>
-            <span class="portal-field-label">Nom de la classe</span>
-            <input class="input" name="class_name" type="text" required placeholder="4t ESO · Matemàtiques" />
-          </label>
-          <label class="portal-form--stack">
-            <span class="portal-field-label">Alumnes (un per línia)</span>
-            <textarea class="input" name="student_list" rows="6" placeholder="Nom alumne 1&#10;Nom alumne 2&#10;..."></textarea>
-            <span class="portal-field-hint">No cal correu ni contrasenya. Els alumnes s'identifiquen amb el seu nom.</span>
-          </label>
-          <div class="portal-actions">
-            <button class="btn-primary" type="submit">Crear classe</button>
-            <div id="classCreateFeedback" class="portal-muted" role="status" aria-live="polite"></div>
-          </div>
-        </form>
+        <div class="dashboard-activity-list">
+          <div><i aria-hidden="true">✓</i><p><strong>Resultats actualitzats</strong><span>Consulta les últimes notes a Resultats.</span></p></div>
+          <div><i aria-hidden="true">◎</i><p><strong>Proves en curs</strong><span id="dashboardActivityTests">Revisa les assignacions actives.</span></p></div>
+          <div><i aria-hidden="true">＋</i><p><strong>Gestiona l'alumnat</strong><span>Obre una classe per editar-ne la llista.</span></p></div>
+        </div>
+        <details class="dashboard-create-class">
+          <summary>＋ Nova classe</summary>
+          <form id="classCreateForm" class="portal-form">
+            <label>
+              <span class="portal-field-label">Nom de la classe</span>
+              <input class="input" name="class_name" type="text" required placeholder="4t ESO · Matemàtiques" />
+            </label>
+            <label class="portal-form--stack">
+              <span class="portal-field-label">Alumnes (un per línia)</span>
+              <textarea class="input" name="student_list" rows="5" placeholder="Nom alumne 1&#10;Nom alumne 2&#10;..."></textarea>
+            </label>
+            <div class="portal-actions">
+              <button class="btn-primary" type="submit">Crear classe</button>
+              <div id="classCreateFeedback" class="portal-muted" role="status" aria-live="polite"></div>
+            </div>
+          </form>
+        </details>
       </section>
 
       <section class="panel card">
         <div class="portal-section-header">
-          <h2>Les meves classes</h2>
-          <p class="portal-muted">Copia el codi o enllaç i comparteix-lo amb l'alumnat.</p>
+          <div><h2>Les meves classes</h2><p class="portal-muted">Seguiment d'activitat i progrés</p></div>
+          <button class="btn-ghost" type="button">Veure-les totes</button>
         </div>
         <div id="classList" class="portal-grid"></div>
         <div id="classEmptyState" class="portal-empty hidden">
@@ -278,10 +303,17 @@
   <template id="classCardTemplate">
     <article class="portal-class-card">
       <header>
-        <p class="portal-chip portal-chip--muted">Classe</p>
-        <h3 class="portal-class-name"></h3>
+        <div>
+          <p class="portal-chip portal-chip--muted">Classe</p>
+          <h3 class="portal-class-name"></h3>
+        </div>
+        <p class="dashboard-class-code"><span>Codi</span><strong></strong></p>
       </header>
       <dl class="portal-class-meta"></dl>
+      <div class="dashboard-class-progress" aria-label="Progrés mitjà">
+        <span class="dashboard-progress-track"><i></i></span>
+        <span class="dashboard-progress-copy"><small>Progrés mitjà</small><strong>0%</strong></span>
+      </div>
       <div class="portal-class-actions">
         <button class="pill portal-class-copy" type="button">Copia enllaç</button>
         <button class="btn-secondary portal-class-edit" type="button">Gestiona alumnes</button>

--- a/portal/supabase-portal.js
+++ b/portal/supabase-portal.js
@@ -59,6 +59,18 @@ const state = {
 
 const elements = {
   configWarning: document.getElementById('configWarning'),
+  portalHero: document.getElementById('portalHero'),
+  portalAuthGrid: document.getElementById('portalAuthGrid'),
+  teacherDashboard: document.getElementById('teacherDashboard'),
+  dashboardFirstName: document.getElementById('dashboardFirstName'),
+  dashboardSearch: document.getElementById('dashboardSearch'),
+  dashboardNewTest: document.getElementById('dashboardNewTest'),
+  dashboardStudentCount: document.getElementById('dashboardStudentCount'),
+  dashboardClassCount: document.getElementById('dashboardClassCount'),
+  dashboardTestCount: document.getElementById('dashboardTestCount'),
+  dashboardPendingCount: document.getElementById('dashboardPendingCount'),
+  dashboardAverage: document.getElementById('dashboardAverage'),
+  sessionAvatar: document.getElementById('sessionAvatar'),
   authPanel: document.getElementById('authPanel'),
   loginForm: document.getElementById('loginForm'),
   authError: document.getElementById('authError'),
@@ -329,14 +341,27 @@ function renderProfileWarning() {
 
 function updateAuthUI() {
   const loggedIn = Boolean(state.session && state.profile);
+  setVisibility(elements.portalHero, !loggedIn);
+  setVisibility(elements.portalAuthGrid, !loggedIn);
+  setVisibility(elements.teacherDashboard, loggedIn);
   setVisibility(elements.authPanel, !loggedIn);
   setVisibility(elements.registerPanel, !loggedIn);
   setVisibility(elements.sessionPanel, loggedIn);
   setVisibility(elements.tabs, loggedIn);
   elements.tabPanels.forEach((panel) => setVisibility(panel, loggedIn && panel.dataset.tabPanel === state.activeTab));
   if (loggedIn) {
-    elements.sessionName.textContent = state.profile.full_name || 'Docent';
-    elements.sessionEmail.textContent = state.profile.email || '';
+    const fullName = state.profile.full_name || 'Docent';
+    const initials = fullName
+      .split(/\s+/)
+      .filter(Boolean)
+      .slice(0, 2)
+      .map((part) => part.charAt(0).toLocaleUpperCase('ca'))
+      .join('');
+    elements.sessionName.textContent = fullName;
+    elements.sessionEmail.textContent = 'Professora';
+    if (elements.sessionAvatar) elements.sessionAvatar.textContent = initials || 'D';
+    if (elements.dashboardFirstName) elements.dashboardFirstName.textContent = fullName.split(/\s+/)[0];
+    renderDashboardSummary();
     switchTab(state.activeTab || 'classes');
   } else {
     state.activeTab = 'classes';
@@ -344,10 +369,28 @@ function updateAuthUI() {
   }
 }
 
+function renderDashboardSummary() {
+  const students = new Set();
+  state.classes.forEach((classroom) => {
+    (classroom.students || []).forEach((student) => students.add(student.trim().toLocaleLowerCase('ca')));
+  });
+  const activeAssignments = state.assignments.filter((assignment) => assignment.status !== 'closed');
+  const grades = state.submissions
+    .map((submission) => Number(submission.score ?? submission.grade))
+    .filter((score) => Number.isFinite(score));
+  const average = grades.length ? grades.reduce((sum, score) => sum + score, 0) / grades.length / 10 : null;
+  if (elements.dashboardStudentCount) elements.dashboardStudentCount.textContent = students.size;
+  if (elements.dashboardClassCount) elements.dashboardClassCount.textContent = state.classes.length;
+  if (elements.dashboardTestCount) elements.dashboardTestCount.textContent = state.assignments.length;
+  if (elements.dashboardPendingCount) elements.dashboardPendingCount.textContent = `${activeAssignments.length} pendents`;
+  if (elements.dashboardAverage) elements.dashboardAverage.textContent = average === null ? '—' : average.toLocaleString('ca-ES', { maximumFractionDigits: 1 });
+}
+
 function switchTab(tab) {
   const loggedIn = Boolean(state.session && state.profile);
   if (!loggedIn) {
     state.activeTab = 'classes';
+    document.body.classList.remove('dashboard-subpage');
     elements.tabButtons.forEach((button) => {
       button.classList.remove('portal-tab--active');
       button.setAttribute('aria-selected', 'false');
@@ -360,6 +403,7 @@ function switchTab(tab) {
   }
 
   state.activeTab = tab;
+  document.body.classList.toggle('dashboard-subpage', tab !== 'classes');
   elements.tabButtons.forEach((button) => {
     const isActive = button.dataset.tab === tab;
     button.classList.toggle('portal-tab--active', isActive);
@@ -858,6 +902,8 @@ function renderClasses() {
     const node = template.content.firstElementChild.cloneNode(true);
     node.dataset.id = cls.id;
     node.querySelector('.portal-class-name').textContent = cls.class_name;
+    const classCode = node.querySelector('.dashboard-class-code strong');
+    if (classCode) classCode.textContent = cls.join_code;
     const metaList = node.querySelector('.portal-class-meta');
     const addMeta = (label, value) => {
       const dt = document.createElement('dt');
@@ -872,6 +918,15 @@ function renderClasses() {
     if (cls.created_at) {
       addMeta('Creada', new Date(cls.created_at).toLocaleString('ca-ES'));
     }
+    const classAssignments = state.assignments.filter((assignment) => assignment.class_id === cls.id);
+    const assignmentIds = new Set(classAssignments.map((assignment) => assignment.id));
+    const submittedCount = state.submissions.filter((submission) => assignmentIds.has(submission.assignment_id)).length;
+    const possibleCount = (cls.students || []).length * classAssignments.length;
+    const progress = possibleCount ? Math.min(100, Math.round((submittedCount / possibleCount) * 100)) : 0;
+    const progressBar = node.querySelector('.dashboard-progress-track i');
+    const progressValue = node.querySelector('.dashboard-progress-copy strong');
+    if (progressBar) progressBar.style.width = `${progress}%`;
+    if (progressValue) progressValue.textContent = `${progress}%`;
     const rosterDetails = node.querySelector('.portal-class-roster');
     const rosterForm = node.querySelector('.portal-class-roster-form');
     const textarea = rosterForm ? rosterForm.querySelector('textarea') : null;
@@ -916,6 +971,7 @@ function renderClasses() {
     node.querySelector('.portal-class-delete').addEventListener('click', () => deleteClass(cls));
     list.appendChild(node);
   });
+  renderDashboardSummary();
 }
 
 function renderAssignments() {
@@ -2022,6 +2078,17 @@ async function refreshData() {
 }
 
 function setupEventListeners() {
+  if (elements.dashboardNewTest) {
+    elements.dashboardNewTest.addEventListener('click', () => switchTab('assignments'));
+  }
+  if (elements.dashboardSearch) {
+    elements.dashboardSearch.addEventListener('input', () => {
+      const query = elements.dashboardSearch.value.trim().toLocaleLowerCase('ca');
+      document.querySelectorAll('#classList .portal-class-card').forEach((card) => {
+        card.classList.toggle('dashboard-filtered', Boolean(query) && !card.textContent.toLocaleLowerCase('ca').includes(query));
+      });
+    });
+  }
   elements.tabButtons.forEach((button) => {
     button.addEventListener('click', () => {
       switchTab(button.dataset.tab);

--- a/profes.html
+++ b/profes.html
@@ -1,0 +1,189 @@
+<!doctype html>
+<html lang="ca">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="description" content="Prototip visual editable del portal docent de FocusQuiz.">
+  <title>FocusQuiz · Portal docent (prototip HTML)</title>
+  <style>
+    :root {
+      --ink: #17223b;
+      --muted: #69748a;
+      --line: #dfe4ef;
+      --paper: #ffffff;
+      --canvas: #f5f6fa;
+      --primary: #6558e8;
+      --primary-soft: #eeeafe;
+      --green: #32b47b;
+      --orange: #f39a51;
+      --radius: 20px;
+      --shadow: 0 18px 45px rgba(39, 45, 78, .08);
+    }
+
+    * { box-sizing: border-box; }
+    body {
+      margin: 0;
+      min-height: 100vh;
+      color: var(--ink);
+      background: var(--canvas);
+      font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+    }
+    button, input { font: inherit; }
+    button { cursor: pointer; }
+    a { color: inherit; text-decoration: none; }
+
+    .app { display: grid; grid-template-columns: 250px minmax(0, 1fr); min-height: 100vh; }
+    .sidebar {
+      display: flex;
+      flex-direction: column;
+      gap: 34px;
+      padding: 28px 20px;
+      color: #f8f8ff;
+      background: #20213d;
+    }
+    .brand { display: flex; align-items: center; gap: 12px; padding: 0 10px; font-size: 1.08rem; font-weight: 800; }
+    .brand-mark { display: grid; place-items: center; width: 38px; height: 38px; border-radius: 12px; background: var(--primary); }
+    .nav { display: grid; gap: 8px; }
+    .nav a { display: flex; align-items: center; gap: 12px; padding: 12px 14px; border-radius: 12px; color: #b8bbd4; font-weight: 650; }
+    .nav a:hover, .nav a.active { color: white; background: rgba(255, 255, 255, .1); }
+    .nav-icon { width: 24px; text-align: center; }
+    .sidebar-help { margin-top: auto; padding: 18px; border-radius: 16px; background: rgba(255, 255, 255, .08); }
+    .sidebar-help strong, .sidebar-help small { display: block; }
+    .sidebar-help small { margin-top: 6px; color: #b8bbd4; line-height: 1.5; }
+
+    .page { min-width: 0; padding: 26px clamp(22px, 4vw, 56px) 54px; }
+    .topbar, .welcome, .section-head, .activity-head { display: flex; align-items: center; justify-content: space-between; gap: 20px; }
+    .search { width: min(420px, 42vw); padding: 11px 16px; border: 1px solid var(--line); border-radius: 12px; background: var(--paper); }
+    .profile { display: flex; align-items: center; gap: 11px; }
+    .avatar { display: grid; place-items: center; width: 42px; height: 42px; border-radius: 50%; color: #453ca6; background: #dcd7ff; font-weight: 800; }
+    .profile small { display: block; color: var(--muted); }
+
+    .welcome { margin: 38px 0 24px; }
+    h1, h2, h3, p { margin-top: 0; }
+    h1 { margin-bottom: 7px; font-size: clamp(1.8rem, 3vw, 2.45rem); letter-spacing: -.04em; }
+    .welcome p, .muted { color: var(--muted); }
+    .primary, .ghost {
+      border: 0;
+      border-radius: 12px;
+      padding: 11px 16px;
+      font-weight: 750;
+    }
+    .primary { color: white; background: var(--primary); box-shadow: 0 10px 20px rgba(101, 88, 232, .22); }
+    .primary:hover { background: #5548da; transform: translateY(-1px); }
+    .ghost { color: var(--ink); background: var(--paper); border: 1px solid var(--line); }
+
+    .stats { display: grid; grid-template-columns: repeat(4, 1fr); gap: 16px; }
+    .card { border: 1px solid var(--line); border-radius: var(--radius); background: var(--paper); box-shadow: var(--shadow); }
+    .stat { padding: 21px; }
+    .stat-top { display: flex; justify-content: space-between; color: var(--muted); font-weight: 650; }
+    .stat-icon { display: grid; place-items: center; width: 36px; height: 36px; border-radius: 11px; background: var(--primary-soft); }
+    .stat strong { display: block; margin-top: 10px; font-size: 1.8rem; }
+    .trend { color: var(--green); font-size: .82rem; font-weight: 750; }
+
+    .content { display: grid; grid-template-columns: minmax(0, 1.65fr) minmax(260px, .75fr); gap: 20px; margin-top: 20px; }
+    .classes, .activity { padding: 24px; }
+    .section-head { margin-bottom: 18px; }
+    .section-head h2, .activity h2 { margin-bottom: 3px; font-size: 1.15rem; }
+    .class-grid { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 14px; }
+    .class-item { padding: 18px; border: 1px solid var(--line); border-radius: 16px; }
+    .class-item:hover { border-color: #aaa1f6; box-shadow: 0 10px 25px rgba(50, 48, 100, .08); }
+    .class-title { display: flex; align-items: flex-start; justify-content: space-between; gap: 10px; }
+    .class-title h3 { margin-bottom: 5px; font-size: 1rem; }
+    .class-dot { width: 10px; height: 10px; margin-top: 6px; border-radius: 50%; background: var(--green); }
+    .progress { height: 7px; margin: 17px 0 9px; overflow: hidden; border-radius: 99px; background: #eceef4; }
+    .progress span { display: block; height: 100%; border-radius: inherit; background: var(--primary); }
+    .class-meta { display: flex; justify-content: space-between; color: var(--muted); font-size: .8rem; }
+
+    .activity-list { display: grid; gap: 18px; margin-top: 20px; }
+    .activity-row { display: grid; grid-template-columns: 39px 1fr; gap: 11px; }
+    .activity-icon { display: grid; place-items: center; height: 39px; border-radius: 12px; background: #edf7f2; }
+    .activity-row p { margin-bottom: 3px; font-size: .9rem; line-height: 1.35; }
+    .activity-row time { color: var(--muted); font-size: .76rem; }
+    .notice { margin-top: 24px; padding: 16px; border-radius: 15px; color: #7c4a20; background: #fff3e7; }
+    .notice strong { display: block; margin-bottom: 4px; }
+
+    .mobile-nav { display: none; }
+    @media (max-width: 980px) {
+      .app { grid-template-columns: 82px minmax(0, 1fr); }
+      .brand-name, .nav-label, .sidebar-help { display: none; }
+      .brand, .nav a { justify-content: center; padding-inline: 0; }
+      .stats { grid-template-columns: repeat(2, 1fr); }
+      .content { grid-template-columns: 1fr; }
+    }
+    @media (max-width: 650px) {
+      .app { display: block; }
+      .sidebar { display: none; }
+      .page { padding: 18px 16px 90px; }
+      .search { width: 100%; }
+      .profile-copy { display: none; }
+      .welcome { align-items: flex-start; margin-top: 28px; }
+      .stats, .class-grid { grid-template-columns: 1fr; }
+      .mobile-nav { position: fixed; z-index: 5; right: 12px; bottom: 12px; left: 12px; display: flex; justify-content: space-around; padding: 10px; border: 1px solid var(--line); border-radius: 17px; background: rgba(255, 255, 255, .94); box-shadow: var(--shadow); backdrop-filter: blur(12px); }
+      .mobile-nav a { padding: 8px 12px; }
+    }
+  </style>
+</head>
+<body>
+  <div class="app">
+    <aside class="sidebar">
+      <a class="brand" href="#"><span class="brand-mark">FQ</span><span class="brand-name">FocusQuiz</span></a>
+      <nav class="nav" aria-label="Navegació del portal docent">
+        <a class="active" href="#inici"><span class="nav-icon">⌂</span><span class="nav-label">Inici</span></a>
+        <a href="#classes"><span class="nav-icon">▦</span><span class="nav-label">Classes</span></a>
+        <a href="#proves"><span class="nav-icon">✓</span><span class="nav-label">Proves</span></a>
+        <a href="#resultats"><span class="nav-icon">↗</span><span class="nav-label">Resultats</span></a>
+        <a href="#recursos"><span class="nav-icon">◇</span><span class="nav-label">Recursos</span></a>
+      </nav>
+      <div class="sidebar-help"><strong>Necessites ajuda?</strong><small>Consulta la guia ràpida per començar amb FocusQuiz.</small></div>
+    </aside>
+
+    <main class="page" id="inici">
+      <header class="topbar">
+        <input class="search" type="search" aria-label="Cerca" placeholder="Cerca classes, alumnes o proves…">
+        <div class="profile"><span class="avatar">MR</span><span class="profile-copy"><strong>Marta Rius</strong><small>Professora</small></span></div>
+      </header>
+
+      <section class="welcome">
+        <div><h1>Bon dia, Marta! 👋</h1><p>Aquí tens un resum de l'activitat de les teves classes.</p></div>
+        <button class="primary" type="button" id="newTest">＋ Nova prova</button>
+      </section>
+
+      <section class="stats" aria-label="Resum del curs">
+        <article class="card stat"><div class="stat-top"><span>Alumnes</span><span class="stat-icon">♙</span></div><strong>84</strong><span class="trend">↑ 6 aquest mes</span></article>
+        <article class="card stat"><div class="stat-top"><span>Classes actives</span><span class="stat-icon">▦</span></div><strong>4</strong><span class="muted">Curs 2025–26</span></article>
+        <article class="card stat"><div class="stat-top"><span>Proves creades</span><span class="stat-icon">✓</span></div><strong>18</strong><span class="trend">3 pendents</span></article>
+        <article class="card stat"><div class="stat-top"><span>Mitjana global</span><span class="stat-icon">↗</span></div><strong>7,8</strong><span class="trend">↑ 0,4 punts</span></article>
+      </section>
+
+      <div class="content">
+        <section class="card classes" id="classes">
+          <div class="section-head"><div><h2>Les meves classes</h2><span class="muted">Seguiment d'activitat i progrés</span></div><button class="ghost" type="button">Veure-les totes</button></div>
+          <div class="class-grid">
+            <article class="class-item"><div class="class-title"><div><h3>4t ESO · Matemàtiques</h3><span class="muted">24 alumnes</span></div><span class="class-dot"></span></div><div class="progress"><span style="width: 78%"></span></div><div class="class-meta"><span>Progrés mitjà</span><strong>78%</strong></div></article>
+            <article class="class-item"><div class="class-title"><div><h3>3r ESO · Català</h3><span class="muted">22 alumnes</span></div><span class="class-dot"></span></div><div class="progress"><span style="width: 64%"></span></div><div class="class-meta"><span>Progrés mitjà</span><strong>64%</strong></div></article>
+            <article class="class-item"><div class="class-title"><div><h3>2n ESO · Geografia</h3><span class="muted">20 alumnes</span></div><span class="class-dot"></span></div><div class="progress"><span style="width: 86%"></span></div><div class="class-meta"><span>Progrés mitjà</span><strong>86%</strong></div></article>
+            <article class="class-item"><div class="class-title"><div><h3>1r ESO · Llengua</h3><span class="muted">18 alumnes</span></div><span class="class-dot" style="background: var(--orange)"></span></div><div class="progress"><span style="width: 51%; background: var(--orange)"></span></div><div class="class-meta"><span>Progrés mitjà</span><strong>51%</strong></div></article>
+          </div>
+        </section>
+
+        <aside class="card activity">
+          <div class="activity-head"><h2>Activitat recent</h2><button class="ghost" type="button" aria-label="Més opcions">•••</button></div>
+          <div class="activity-list">
+            <div class="activity-row"><span class="activity-icon">✓</span><div><p><strong>Laia</strong> ha completat «Fraccions» amb un 9,2.</p><time>Fa 12 minuts</time></div></div>
+            <div class="activity-row"><span class="activity-icon">◎</span><div><p><strong>18 alumnes</strong> han començat la prova de català.</p><time>Fa 1 hora</time></div></div>
+            <div class="activity-row"><span class="activity-icon">＋</span><div><p>S'ha afegit <strong>Pol Garcia</strong> a 4t ESO.</p><time>Ahir, 16:40</time></div></div>
+          </div>
+          <div class="notice"><strong>Prova pendent</strong><span>La prova «Accentuació» es tanca demà.</span></div>
+        </aside>
+      </div>
+    </main>
+  </div>
+
+  <nav class="mobile-nav" aria-label="Navegació mòbil"><a href="#inici">⌂</a><a href="#classes">▦</a><a href="#proves">✓</a><a href="#resultats">↗</a></nav>
+  <script>
+    document.querySelector('#newTest').addEventListener('click', () => {
+      window.alert('Prototip visual: aquí pots connectar el formulari de creació de proves.');
+    });
+  </script>
+</body>
+</html>


### PR DESCRIPTION
### Motivation
- Replace the old portal layout with an approved teacher-focused dashboard design and rebrand the portal from "Focus Academy" to "FocusQuiz". 
- Expose a compact dashboard for teachers with quick overviews of classes, tests and results to improve usability.

### Description
- Added a comprehensive teacher dashboard stylesheet and responsive rules under `portal/portal.css` scoped to `body.teacher-portal` to implement the approved visual layout and components. 
- Updated `portal/supabase-portal.html` to rework the portal markup: added the dashboard hero, stats, activity list, search, tabs, sign-in/register layout changes, and accessible tab controls, and updated meta/title/description text. 
- Enhanced `portal/supabase-portal.js` to wire up dashboard UI: new `elements` entries, `renderDashboardSummary()` to compute counts/average, initials/avatar rendering, search filtering, new event listeners, visibility toggles, progress bar rendering in class cards, and minor tab/`dashboard-subpage` state handling. 
- Added a new static prototype `profes.html` as a visual HTML prototype of the teacher portal for design review. 

### Testing
- No automated test suite was executed as part of this change; manual smoke checks were performed during development (UI rendering and interaction flows), and files were linted in the editor environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7f92699ef8832d9e1341507f56e709)